### PR TITLE
Fixes #1: SQS Span Collector

### DIFF
--- a/aws-junit/pom.xml
+++ b/aws-junit/pom.xml
@@ -14,7 +14,10 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -23,18 +26,18 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-sender-sqs</artifactId>
-  <name>Zipkin Sender: AWS SQS</name>
+  <artifactId>zipkin-aws-junit</artifactId>
+  <name>Zipkin AWS JUnit Rules</name>
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+
+    <!-- Test use Java8 -->
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>io.zipkin.reporter</groupId>
-      <artifactId>zipkin-reporter</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -42,17 +45,15 @@
     </dependency>
 
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-aws-junit</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>org.elasticmq</groupId>
       <artifactId>elasticmq-server_2.11</artifactId>
       <version>0.10.0</version>
-      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/collector-sqs/pom.xml
+++ b/collector-sqs/pom.xml
@@ -14,31 +14,43 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
-    <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
+    <groupId>io.zipkin.aws</groupId>
     <version>0.0.1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-sender-sqs</artifactId>
-  <name>Zipkin Sender: AWS SQS</name>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>zipkin-collector-sqs</artifactId>
+  <name>Zipkin Collector: AWS SQS</name>
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+
+    <!-- Zipkin server uses Java8 so override parent settings -->
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>io.zipkin.reporter</groupId>
-      <artifactId>zipkin-reporter</artifactId>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sqs</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -48,12 +60,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.elasticmq</groupId>
-      <artifactId>elasticmq-server_2.11</artifactId>
-      <version>0.10.0</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
+
 </project>

--- a/collector-sqs/src/main/java/zipkin/collector/sqs/AwsSqsCollector.java
+++ b/collector-sqs/src/main/java/zipkin/collector/sqs/AwsSqsCollector.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.collector.sqs;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.buffered.AmazonSQSBufferedAsyncClient;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import zipkin.Component;
+import zipkin.collector.Collector;
+import zipkin.collector.CollectorComponent;
+import zipkin.collector.CollectorMetrics;
+import zipkin.collector.CollectorSampler;
+import zipkin.internal.LazyCloseable;
+import zipkin.internal.Util;
+import zipkin.storage.StorageComponent;
+import static zipkin.internal.Util.*;
+
+
+public final class AwsSqsCollector implements CollectorComponent, Closeable {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder implements CollectorComponent.Builder {
+
+    Collector.Builder delegate = Collector.builder(AwsSqsCollector.class);
+
+    String queueUrl;
+    int waitTimeSeconds = 20; // aws sqs max wait time is 20 seconds
+    AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
+    int parallelism = 1;
+
+    @Override public CollectorComponent.Builder storage(StorageComponent storageComponent) {
+      delegate.storage(storageComponent);
+      return this;
+    }
+
+    @Override public CollectorComponent.Builder metrics(CollectorMetrics metrics) {
+      delegate.metrics(Util.checkNotNull(metrics, "metrics").forTransport("sqs"));
+      return this;
+    }
+
+    @Override public CollectorComponent.Builder sampler(CollectorSampler sampler) {
+      delegate.sampler(sampler);
+      return this;
+    }
+
+    /** SQS queue URL to consume from */
+    public Builder queueUrl(String queueUrl) {
+      this.queueUrl = queueUrl;
+      return this;
+    }
+
+    /** AWS credentials for authenticating calls to SQS. */
+    public Builder credentialsProvider(AWSCredentialsProvider credentialsProvider) {
+      this.credentialsProvider = credentialsProvider;
+      return this;
+    }
+
+    /** Amount of time to wait for messages from SQS */
+    public Builder waitTimeSeconds(int seconds) {
+      checkArgument(parallelism > 0 && parallelism < 21, "parallelism");
+      this.waitTimeSeconds = seconds;
+      return this;
+    }
+
+    /** How many processors to run in parallel for each queue URL */
+    public Builder parallelism(int parallelism) {
+      checkArgument(parallelism > 0, "parallelism");
+      this.parallelism = parallelism;
+      return this;
+    }
+
+    @Override public CollectorComponent build() {
+      return new AwsSqsCollector(this);
+    }
+
+    Builder() {
+    }
+  }
+
+  private final LazyAmazonSQSAsync client;
+  private final LazyProcessors processors;
+
+  AwsSqsCollector(Builder builder) {
+    client = new LazyAmazonSQSAsync(builder.credentialsProvider);
+    processors = new LazyProcessors(client.get(), builder.delegate.build(), builder.queueUrl,
+        builder.parallelism, builder.waitTimeSeconds);
+  }
+
+  @Override public CollectorComponent start() {
+    processors.get();
+    return this;
+  }
+
+  @Override public CheckResult check() {
+    try {
+      client.get(); // make sure compute doesn't throw an exception
+      return processors.check(); // check if any processor has failed
+    } catch (RuntimeException e) {
+      return CheckResult.failed(e);
+    }
+  }
+
+  @Override public void close() throws IOException {
+    client.close();
+    processors.close();
+  }
+
+  private static final class LazyProcessors extends LazyCloseable<List<AwsSqsSpanProcessor>>
+      implements Component {
+
+    private static final Logger logger = Logger.getLogger(LazyProcessors.class.getName());
+
+    final String queueUrl;
+    final int parallelism;
+    final AmazonSQSAsync client;
+    final Collector collector;
+    final int waitTimeSeconds;
+
+    LazyProcessors(AmazonSQSAsync client, Collector collector, String queueUrl, int parallelism, int waitTimeSeconds) {
+      this.queueUrl = queueUrl;
+      this.parallelism = parallelism;
+      this.client = client;
+      this.collector = collector;
+      this.waitTimeSeconds = waitTimeSeconds;
+    }
+
+    @Override protected List<AwsSqsSpanProcessor> compute() {
+      return IntStream.range(0, parallelism - 1)
+          .mapToObj(i -> new AwsSqsSpanProcessor(client, collector, queueUrl, waitTimeSeconds).run())
+          .collect(Collectors.toList());
+    }
+
+    @Override public CheckResult check() {
+      List<AwsSqsSpanProcessor> processors = maybeNull();
+      if (processors != null) {
+        for (AwsSqsSpanProcessor processor : processors) {
+          CheckResult result = processor.check();
+          if (result != CheckResult.OK) return result;
+        }
+      }
+      return CheckResult.OK;
+    }
+
+    @Override public void close() {
+      List<AwsSqsSpanProcessor> processors = maybeNull();
+      if (processors == null) return;
+
+      for (AwsSqsSpanProcessor processor : processors) {
+        try {
+          processor.close();
+        } catch (IOException ioe) {
+          logger.log(Level.WARNING, "Processor failed to close cleanly", ioe);
+        }
+      }
+    }
+  }
+
+  private static final class LazyAmazonSQSAsync extends LazyCloseable<AmazonSQSAsync> {
+
+    final AWSCredentialsProvider credentialsProvider;
+
+    LazyAmazonSQSAsync(AWSCredentialsProvider credentialsProvider) {
+      this.credentialsProvider = credentialsProvider;
+    }
+
+    @Override protected AmazonSQSAsync compute() {
+      return new AmazonSQSBufferedAsyncClient(new AmazonSQSAsyncClient(credentialsProvider));
+    }
+
+    @Override public void close() {
+      AmazonSQS client = maybeNull();
+      if (client == null) return;
+
+      client.shutdown();
+    }
+  }
+
+}

--- a/collector-sqs/src/main/java/zipkin/collector/sqs/AwsSqsSpanProcessor.java
+++ b/collector-sqs/src/main/java/zipkin/collector/sqs/AwsSqsSpanProcessor.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.collector.sqs;
+
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.DeleteMessageResult;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+import zipkin.Codec;
+import zipkin.Component;
+import zipkin.collector.Collector;
+import zipkin.internal.Nullable;
+import zipkin.storage.Callback;
+
+
+final class AwsSqsSpanProcessor implements Closeable, Component {
+
+  private static final Logger logger = Logger.getLogger(AwsSqsSpanProcessor.class.getName());
+
+  private final AmazonSQSAsync client;
+  private final Collector collector;
+  private final String queueUrl;
+  private final int waitTimeSeconds;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final AtomicReference<CheckResult> status = new AtomicReference<>(CheckResult.OK);
+
+  AwsSqsSpanProcessor(AmazonSQSAsync client, Collector collector, String queueUrl,
+      int waitTimeSeconds) {
+    this.client = client;
+    this.collector = collector;
+    this.queueUrl = queueUrl;
+    this.waitTimeSeconds = waitTimeSeconds;
+  }
+
+  @Override public CheckResult check() {
+    return status.get();
+  }
+
+  @Override public void close() throws IOException {
+    if (closed.getAndSet(true)) throw new IllegalStateException("SQS processor is already closed.");
+    client.shutdown();
+  }
+
+  AwsSqsSpanProcessor run() {
+    // don't throw an exception here since this might be run from a receive callback.
+    if (closed.get()) return null;
+
+    ReceiveMessageRequest request = new ReceiveMessageRequest(queueUrl)
+        .withWaitTimeSeconds(waitTimeSeconds)
+        .withMessageAttributeNames("spans");
+
+    client.receiveMessageAsync(request,
+        new AsyncHandler<ReceiveMessageRequest, ReceiveMessageResult>() {
+          @Override public void onError(Exception exception) {
+            // TODO when should this just give up?
+            status.set(CheckResult.failed(exception));
+            run();
+          }
+
+          @Override
+          public void onSuccess(ReceiveMessageRequest request, ReceiveMessageResult result) {
+            process(result.getMessages());
+            status.lazySet(CheckResult.OK);
+            run();
+          }
+        });
+
+    return this;
+  }
+
+  private void process(final List<Message> messages) {
+
+    for (Message message : messages) {
+      MessageAttributeValue spanAttributes = message.getMessageAttributes().get("spans");
+      if (spanAttributes != null) {
+        byte[] bytes = spanAttributes.getBinaryValue().array();
+
+        String type = spanAttributes.getDataType();
+        Codec codec = null;
+        if ("Binary.JSON".equals(type)) { codec = Codec.JSON; }
+        else if ("Binary.THRIFT".equals(type)) { codec = Codec.THRIFT; }
+
+        if (codec == null) {
+          logger.warning(String.format("Unsupported codec %s", spanAttributes.getDataType()));
+          delete(message);
+        } else {
+          collector.acceptSpans(bytes, codec, new Callback<Void>() {
+            @Override public void onSuccess(@Nullable Void value) {
+              delete(message);
+            }
+            @Override public void onError(Throwable t) {
+              // don't delete messages. this will allow accept calls retry once the
+              // messages are marked visible by sqs.
+            }
+          });
+        }
+      }
+    }
+  }
+
+  private Future<DeleteMessageResult> delete(Message message) {
+    // client will buffer deletes on its own to minimize API calls.
+    return client.deleteMessageAsync(queueUrl, message.getReceiptHandle());
+  }
+
+}

--- a/collector-sqs/src/test/java/zipkin/collector/sqs/AwsSqsCollectorTest.java
+++ b/collector-sqs/src/test/java/zipkin/collector/sqs/AwsSqsCollectorTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.collector.sqs;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import zipkin.Span;
+import zipkin.TestObjects;
+import zipkin.collector.CollectorComponent;
+import zipkin.collector.CollectorMetrics;
+import zipkin.collector.CollectorSampler;
+import zipkin.junit.aws.AmazonSqsRule;
+import zipkin.storage.InMemoryStorage;
+import zipkin.storage.QueryRequest;
+import zipkin.storage.StorageComponent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static zipkin.TestObjects.TRACE;
+
+public class AwsSqsCollectorTest {
+
+  @Rule
+  public AmazonSqsRule sqsRule = new AmazonSqsRule().start(9324);
+
+  private StorageComponent store;
+
+  private CollectorComponent collector;
+
+  @Before
+  public void setup() {
+    store = new InMemoryStorage();
+
+    collector = new AwsSqsCollector.Builder()
+        .queueUrl(sqsRule.queueUrl())
+        .parallelism(2)
+        .credentialsProvider(new AWSStaticCredentialsProvider(new BasicAWSCredentials("x", "x")))
+        .metrics(CollectorMetrics.NOOP_METRICS)
+        .sampler(CollectorSampler.ALWAYS_SAMPLE)
+        .storage(store)
+        .build()
+        .start();
+  }
+
+  @After
+  public void teardown() throws Exception {
+    store.close();
+    collector.close();
+  }
+
+  @Test
+  public void collectSpans() throws Exception {
+
+    sqsRule.sendTraces(TRACE);
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> store.spanStore().getRawTrace(TRACE.get(0).traceId) != null);
+
+    List<Span> fromStore = store.spanStore().getRawTrace(TRACE.get(0).traceId);
+
+    assertThat(fromStore).isNotNull().as("recorded spans should not be null");
+    assertThat(fromStore.size()).isEqualTo(TRACE.size()).as("all spans have been recorded");
+    assertThat(sqsRule.queueCount()).isEqualTo(0).as("accepted spans are deleted.");
+  }
+
+  @Test
+  public void collectLotsOfSpans() throws Exception {
+
+    Span[] LOTS = new Random().longs(10000L).mapToObj(TestObjects::span).toArray(Span[]::new);
+
+    sqsRule.sendTraces(Arrays.asList(LOTS));
+
+    QueryRequest query = QueryRequest.builder().serviceName("service").limit(LOTS.length).build();
+
+    await()
+        .atMost(15, TimeUnit.SECONDS)
+        .until(() -> {
+          List<List<Span>> spans = store.spanStore().getTraces(query);
+          return (spans != null && spans.size() == LOTS.length);
+        });
+
+    List<List<Span>> fromStore = store.spanStore().getTraces(query);
+
+    assertThat(fromStore).isNotNull().as("recorded spans should not be null");
+    assertThat(fromStore.size()).isEqualTo(LOTS.length).as("all spans have been accepted.");
+    assertThat(sqsRule.queueCount()).isEqualTo(0).as("accepted spans as deleted.");
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,333 +15,352 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.zipkin.aws</groupId>
-    <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <packaging>pom</packaging>
+  <groupId>io.zipkin.aws</groupId>
+  <artifactId>zipkin-aws-parent</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
-    <modules>
-        <module>sender-sqs</module>
-    </modules>
+  <modules>
+    <module>sender-sqs</module>
+    <module>collector-sqs</module>
+    <module>aws-junit</module>
+  </modules>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
-        <!-- default bytecode version for src/main -->
-        <main.java.version>1.6</main.java.version>
-        <main.signature.artifact>java16</main.signature.artifact>
+    <!-- default bytecode version for src/main -->
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
 
-        <main.basedir>${project.basedir}</main.basedir>
+    <main.basedir>${project.basedir}</main.basedir>
 
-        <license-maven-plugin.version>2.11</license-maven-plugin.version>
+    <license-maven-plugin.version>2.11</license-maven-plugin.version>
 
-        <zipkin.version>1.12.1</zipkin.version>
-        <zipkin-reporter.version>0.5.2</zipkin-reporter.version>
+    <zipkin.version>1.12.1</zipkin.version>
+    <zipkin-reporter.version>0.5.2</zipkin-reporter.version>
 
-        <aws-java-sdk.version>1.11.38</aws-java-sdk.version>
-    </properties>
+    <slf4j.version>1.7.21</slf4j.version>
 
-    <name>Zipkin AWS (Parent)</name>
-    <description>Zipkin AWS (Parent)</description>
+    <aws-java-sdk.version>1.11.38</aws-java-sdk.version>
+  </properties>
+
+  <name>Zipkin AWS (Parent)</name>
+  <description>Zipkin AWS (Parent)</description>
+  <url>https://github.com/openzipkin/zipkin-aws</url>
+  <inceptionYear>2016</inceptionYear>
+
+  <organization>
+    <name>OpenZipkin</name>
+    <url>http://zipkin.io/</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
     <url>https://github.com/openzipkin/zipkin-aws</url>
-    <inceptionYear>2016</inceptionYear>
+    <connection>scm:git:https://github.com/openzipkin/zipkin-aws.git</connection>
+    <developerConnection>scm:git:https://github.com/openzipkin/zipkin-aws.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
 
-    <organization>
-        <name>OpenZipkin</name>
-        <url>http://zipkin.io/</url>
-    </organization>
+  <developers>
+    <developer>
+      <id>adriancole</id>
+      <name>Adrian Cole</name>
+      <email>acole@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>lancelinder</id>
+      <name>Lance Linder</name>
+      <email>lance@smartthings.com</email>
+    </developer>
+  </developers>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+  <distributionManagement>
+    <repository>
+      <id>bintray</id>
+      <url>https://api.bintray.com/maven/openzipkin/maven/zipkin-aws/;publish=1</url>
+    </repository>
+    <snapshotRepository>
+      <id>jfrog-snapshots</id>
+      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+    </snapshotRepository>
+  </distributionManagement>
 
-    <scm>
-        <url>https://github.com/openzipkin/zipkin-aws</url>
-        <connection>scm:git:https://github.com/openzipkin/zipkin-aws.git</connection>
-        <developerConnection>scm:git:https://github.com/openzipkin/zipkin-aws.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
+  <issueManagement>
+    <system>Github</system>
+    <url>https://github.com/openzipkin/zipkin-aws/issues</url>
+  </issueManagement>
 
-    <developers>
-        <developer>
-            <id>adriancole</id>
-            <name>Adrian Cole</name>
-            <email>acole@pivotal.io</email>
-        </developer>
-    </developers>
-
-    <distributionManagement>
-        <repository>
-            <id>bintray</id>
-            <url>https://api.bintray.com/maven/openzipkin/maven/zipkin-aws/;publish=1</url>
-        </repository>
-        <snapshotRepository>
-            <id>jfrog-snapshots</id>
-            <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-        </snapshotRepository>
-    </distributionManagement>
-
-    <issueManagement>
-        <system>Github</system>
-        <url>https://github.com/openzipkin/zipkin-aws/issues</url>
-    </issueManagement>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.zipkin.java</groupId>
-                <artifactId>zipkin</artifactId>
-                <version>${zipkin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.zipkin.reporter</groupId>
-                <artifactId>zipkin-reporter</artifactId>
-                <version>${zipkin-reporter.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>${aws-java-sdk.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>io.zipkin.java</groupId>
-            <artifactId>zipkin</artifactId>
-            <version>${zipkin.version}</version>
-        </dependency>
-        <!-- don't worry. auto-* are source retention, not runtime -->
-        <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value</artifactId>
-            <version>1.3</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.5.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.zipkin.java</groupId>
-            <artifactId>zipkin</artifactId>
-            <version>${zipkin.version}</version>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>io.zipkin.java</groupId>
+        <artifactId>zipkin</artifactId>
+        <version>${zipkin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.zipkin.reporter</groupId>
+        <artifactId>zipkin-reporter</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>${aws-java-sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>${zipkin.version}</version>
+    </dependency>
+
+    <!-- don't worry. auto-* are source retention, not runtime -->
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <version>1.3</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.5.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>${zipkin.version}</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.7</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <!-- mvn -N io.takari:maven:wrapper -Dmaven=3.3.9 -->
-                <plugin>
-                    <groupId>io.takari</groupId>
-                    <artifactId>maven</artifactId>
-                    <version>0.3.3</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- mvn -N io.takari:maven:wrapper -Dmaven=3.3.9 -->
+        <plugin>
+          <groupId>io.takari</groupId>
+          <artifactId>maven</artifactId>
+          <version>0.3.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
 
+    <plugins>
+      <plugin>
+        <inherited>true</inherited>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
+          <source>1.8</source>
+          <target>1.8</target>
+          <compilerId>javac-with-errorprone</compilerId>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <showWarnings>true</showWarnings>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+            <version>2.8</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <version>2.0.9</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <version>2.3.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>process-main</goal>
+            </goals>
+            <configuration>
+              <target>${main.java.version}</target>
+              <fork>false</fork>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.15</version>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>${main.signature.artifact}</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Ensures checksums are added to published jars -->
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <configuration>
+          <createChecksum>true</createChecksum>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>${license-maven-plugin.version}</version>
+        <configuration>
+          <header>${main.basedir}/src/etc/header.txt</header>
+          <excludes>
+            <exclude>.travis.yml</exclude>
+            <exclude>.gitignore</exclude>
+            <exclude>.mvn/**</exclude>
+            <exclude>mvnw*</exclude>
+            <exclude>etc/header.txt</exclude>
+            <exclude>**/.idea/**</exclude>
+            <exclude>LICENSE</exclude>
+            <exclude>**/*.md</exclude>
+            <exclude>src/test/resources/**</exclude>
+            <exclude>src/main/resources/**</exclude>
+          </excludes>
+          <strictCheck>true</strictCheck>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin-git</artifactId>
+            <version>${license-maven-plugin.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <tagNameFormat>@{project.version}</tagNameFormat>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>io.zipkin.centralsync-maven-plugin</groupId>
+        <artifactId>centralsync-maven-plugin</artifactId>
+        <version>0.1.0</version>
+        <configuration>
+          <packageName>zipkin-aws</packageName>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
         <plugins>
-            <plugin>
-                <inherited>true</inherited>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <compilerId>javac-with-errorprone</compilerId>
-                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                    <showWarnings>true</showWarnings>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.plexus</groupId>
-                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_core</artifactId>
-                        <version>2.0.9</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
+          <!-- Creates source jar -->
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
 
-            <plugin>
-                <groupId>net.orfjackal.retrolambda</groupId>
-                <artifactId>retrolambda-maven-plugin</artifactId>
-                <version>2.3.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>process-main</goal>
-                        </goals>
-                        <configuration>
-                            <target>${main.java.version}</target>
-                            <fork>false</fork>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>${main.signature.artifact}</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Ensures checksums are added to published jars -->
-            <plugin>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-                <configuration>
-                    <createChecksum>true</createChecksum>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>${license-maven-plugin.version}</version>
-                <configuration>
-                    <header>${main.basedir}/src/etc/header.txt</header>
-                    <excludes>
-                        <exclude>.travis.yml</exclude>
-                        <exclude>.gitignore</exclude>
-                        <exclude>.mvn/**</exclude>
-                        <exclude>mvnw*</exclude>
-                        <exclude>etc/header.txt</exclude>
-                        <exclude>**/.idea/**</exclude>
-                        <exclude>LICENSE</exclude>
-                        <exclude>**/*.md</exclude>
-                        <exclude>src/test/resources/**</exclude>
-                        <exclude>src/main/resources/**</exclude>
-                    </excludes>
-                    <strictCheck>true</strictCheck>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.mycila</groupId>
-                        <artifactId>license-maven-plugin-git</artifactId>
-                        <version>${license-maven-plugin.version}</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>compile</phase>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>release</releaseProfiles>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>io.zipkin.centralsync-maven-plugin</groupId>
-                <artifactId>centralsync-maven-plugin</artifactId>
-                <version>0.1.0</version>
-                <configuration>
-                    <packageName>zipkin-aws</packageName>
-                </configuration>
-            </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.4</version>
+            <configuration>
+              <failOnError>false</failOnError>
+              <excludePackageNames>zipkin.aws.internal,zipkin.aws.internal.*
+              </excludePackageNames>
+              <!-- hush pedantic warnings: we don't put param and return on everything! -->
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
-    </build>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <!-- Creates source jar -->
-                    <plugin>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
-                        <configuration>
-                            <failOnError>false</failOnError>
-                            <excludePackageNames>zipkin.aws.internal,zipkin.aws.internal.*
-                            </excludePackageNames>
-                            <!-- hush pedantic warnings: we don't put param and return on everything! -->
-                            <additionalparam>-Xdoclint:none</additionalparam>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <phase>package</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/sender-sqs/src/main/java/zipkin/reporter/sqs/AwsBufferedSqsSender.java
+++ b/sender-sqs/src/main/java/zipkin/reporter/sqs/AwsBufferedSqsSender.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.reporter.awssqs;
+package zipkin.reporter.sqs;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;

--- a/sender-sqs/src/test/java/zipkin/reporter/sqs/AwsBufferedSqsSenderTest.java
+++ b/sender-sqs/src/test/java/zipkin/reporter/sqs/AwsBufferedSqsSenderTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin.reporter.awssqs;
+package zipkin.reporter.sqs;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -27,6 +27,8 @@ import zipkin.reporter.internal.AwaitableCallback;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import zipkin.junit.aws.AmazonSqsRule;
 
 public class AwsBufferedSqsSenderTest {
 


### PR DESCRIPTION
An alternative Zipkin Span Collector implementation that leverages the AmazonSqsAsync callback API to chain SQS reads.

This implementation also allows a list of queue URLs to pull messages from multiple sources.

Further this takes advantage of the thread pool provided by the Amazon client as well as prefetching capabilities of the buffered client.