### PR TITLE
Fixes #4: CI release configuration setup

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype</id>
+      <username>${env.SONATYPE_USER}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>bintray</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>jfrog-snapshots</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>github.com</id>
+      <username>${env.GH_USER}</username>
+      <password>${env.GH_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/build-support/publish-snapshot.sh
+++ b/build-support/publish-snapshot.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -euo pipefail
+set -x
+
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -pl -:benchmarks -DskipTests deploy

--- a/build-support/publish-stable.sh
+++ b/build-support/publish-stable.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -euo pipefail
+set -x
+
+./mvnw -DskipTests install -nsu
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -pl -:benchmarks -DskipTests deploy
+./mvnw --batch-mode -s ./.settings.xml -nsu -N io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync

--- a/build-support/trigger-publish.sh
+++ b/build-support/trigger-publish.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -euo pipefail
+set -x
+
+release_version() {
+    echo "${CIRCLE_TAG}" | sed 's/^release-//'
+}
+
+safe_checkout_master() {
+  # We need to be on a branch for release:perform to be able to create commits, and we want that branch to be master.
+  # But we also want to make sure that we build and release exactly the tagged version, so we verify that the remote
+  # master is where our tag is.
+  git checkout -B master
+  git fetch origin master:origin/master
+  commit_local_master="$(git show --pretty='format:%H' master)"
+  commit_remote_master="$(git show --pretty='format:%H' origin/master)"
+  if [ "$commit_local_master" != "$commit_remote_master" ]; then
+    echo "Master on remote 'origin' has commits since the version under release, aborting"
+    exit 1
+  fi
+}
+
+safe_checkout_master
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare

--- a/circle.yml
+++ b/circle.yml
@@ -25,3 +25,25 @@ test:
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+
+# Send notifications to Gitter
+notify:
+  webhooks:
+    - url: https://webhooks.gitter.im/e/22adbb9973299092e6ae
+
+deployment:
+  trigger:
+    owner: openzipkin
+    tag: /release-\d+\.\d+\.\d+/
+    commands:
+      - ./circleci/trigger-publish.sh
+  publish-stable:
+    owner: openzipkin
+    tag: /\d+\.\d+\.\d+/
+    commands:
+      - ./circleci/publish-stable.sh
+  publish-snapshot:
+    owner: openzipkin
+    branch: master
+    commands:
+      - ./circleci/publish-snapshot.sh


### PR DESCRIPTION
This pulls in release scripts and CircleCI deployment config started by @abesto here https://github.com/openzipkin/zipkin-aws/tree/circleci

I've gone ahead and added ENV vars in CircleCI for my accounts.  I believe my accounts have the necessary permissions though there might be some debugging post merge.