### PR TITLE
Fixes #24: use kebab case names for sqs auto config

### DIFF
--- a/autoconfigure/collector-sqs/pom.xml
+++ b/autoconfigure/collector-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-autoconfigure</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-autoconfigure-collector-sqs</artifactId>

--- a/autoconfigure/collector-sqs/src/main/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCollectorAutoConfiguration.java
+++ b/autoconfigure/collector-sqs/src/main/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCollectorAutoConfiguration.java
@@ -63,12 +63,12 @@ public class ZipkinSQSCollectorAutoConfiguration {
    * doesn't have an option to treat empty properties as unset.
    *
    * <pre>{@code
-   * queueUrl: ${SQS_QUEUE_URL:}
+   * queue-url: ${SQS_QUEUE_URL:}
    * }</pre>
    */
   static final class SQSSetCondition extends SpringBootCondition {
 
-    private static final String PROPERTY_NAME = "zipkin.collector.sqs.queueUrl";
+    private static final String PROPERTY_NAME = "zipkin.collector.sqs.queue-url";
 
     @Override public ConditionOutcome getMatchOutcome(ConditionContext context,
         AnnotatedTypeMetadata a) {

--- a/autoconfigure/collector-sqs/src/test/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCollectorAutoConfigurationTest.java
+++ b/autoconfigure/collector-sqs/src/test/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCollectorAutoConfigurationTest.java
@@ -64,8 +64,8 @@ public class ZipkinSQSCollectorAutoConfigurationTest {
   @Test
   public void provideCollectorComponent_whenSqsQueueUrlIsSet() {
     context = new AnnotationConfigApplicationContext();
-    addEnvironment(context, "zipkin.collector.sqs.queueUrl:" + sqsRule.queueUrl());
-    addEnvironment(context, "zipkin.collector.sqs.waitTimeSeconds:1");
+    addEnvironment(context, "zipkin.collector.sqs.queue-url:" + sqsRule.queueUrl());
+    addEnvironment(context, "zipkin.collector.sqs.wait-time-seconds:1");
     context.register(PropertyPlaceholderAutoConfiguration.class,
         ZipkinSQSCollectorAutoConfiguration.class, InMemoryConfiguration.class);
     context.refresh();
@@ -77,8 +77,8 @@ public class ZipkinSQSCollectorAutoConfigurationTest {
   @Test
   public void provideCollectorComponent_setsZipkinSqsCollectorProperties() {
     context = new AnnotationConfigApplicationContext();
-    addEnvironment(context, "zipkin.collector.sqs.queueUrl:" + sqsRule.queueUrl());
-    addEnvironment(context, "zipkin.collector.sqs.waitTimeSeconds:1");
+    addEnvironment(context, "zipkin.collector.sqs.queue-url:" + sqsRule.queueUrl());
+    addEnvironment(context, "zipkin.collector.sqs.wait-time-seconds:1");
     addEnvironment(context, "zipkin.collector.sqs.parallelism:3");
     context.register(PropertyPlaceholderAutoConfiguration.class,
         ZipkinSQSCollectorAutoConfiguration.class, InMemoryConfiguration.class);

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-autoconfigure</artifactId>

--- a/aws-junit/pom.xml
+++ b/aws-junit/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-aws-junit</artifactId>

--- a/collector-sqs/pom.xml
+++ b/collector-sqs/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.aws</groupId>
   <artifactId>zipkin-aws-parent</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/sender-sqs/pom.xml
+++ b/sender-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-sqs</artifactId>


### PR DESCRIPTION
This changes config like `queueUrl` to `queue-url` and also updates the POM files with the correct snapshot version.  The snapshot version should have been done last release so that needs some investigation.