### PR TITLE
Resolve async SQS issue when queue is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![CircleCI](https://circleci.com/gh/openzipkin/zipkin-aws.svg?style=svg)](https://circleci.com/gh/openzipkin/zipkin-aws)
+[![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin)
+[![Build Status](https://circleci.com/gh/openzipkin/zipkin-aws.svg?style=svg)](https://circleci.com/gh/openzipkin/zipkin-aws)
+[![Download](https://api.bintray.com/packages/openzipkin/maven/zipkin-aws/images/download.svg)](https://bintray.com/openzipkin/maven/zipkin-aws/_latestVersion)
 
 # zipkin-aws
 Shared libraries that provide Zipkin integration with AWS SQS and SNS. Requires JRE 6 or later.

--- a/autoconfigure/collector-sqs/pom.xml
+++ b/autoconfigure/collector-sqs/pom.xml
@@ -37,6 +37,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-aws-junit</artifactId>
       <version>${project.version}</version>

--- a/autoconfigure/collector-sqs/src/main/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCollectorAutoConfiguration.java
+++ b/autoconfigure/collector-sqs/src/main/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCollectorAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,9 +14,7 @@
 package zipkin.autoconfigure.collector.sqs;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -34,20 +32,14 @@ import zipkin.storage.StorageComponent;
 @Conditional(ZipkinSQSCollectorAutoConfiguration.SQSSetCondition.class)
 public class ZipkinSQSCollectorAutoConfiguration {
 
-  /** By default, get credentials from the {@link DefaultAWSCredentialsProviderChain */
   @Bean
-  @ConditionalOnMissingBean
-  AWSCredentialsProvider credentialsProvider() {
-    return new DefaultAWSCredentialsProviderChain();
-  }
-
-  @Bean SQSCollector sqs(ZipkinSQSCollectorProperties sqs, AWSCredentialsProvider provider,
+  SQSCollector sqsCollector(ZipkinSQSCollectorProperties properties, AWSCredentialsProvider credentialsProvider,
       CollectorSampler sampler, CollectorMetrics metrics, StorageComponent storage) {
-    return sqs.toBuilder()
-        .queueUrl(sqs.getQueueUrl())
-        .waitTimeSeconds(sqs.getWaitTimeSeconds())
-        .parallelism(sqs.getParallelism())
-        .credentialsProvider(provider)
+    return properties.toBuilder()
+        .queueUrl(properties.getQueueUrl())
+        .waitTimeSeconds(properties.getWaitTimeSeconds())
+        .parallelism(properties.getParallelism())
+        .credentialsProvider(credentialsProvider)
         .sampler(sampler)
         .metrics(metrics)
         .storage(storage)
@@ -84,5 +76,7 @@ public class ZipkinSQSCollectorAutoConfiguration {
       return s == null || s.isEmpty();
     }
   }
+
+
 
 }

--- a/autoconfigure/collector-sqs/src/main/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCollectorProperties.java
+++ b/autoconfigure/collector-sqs/src/main/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCollectorProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,6 +21,11 @@ final public class ZipkinSQSCollectorProperties {
   String queueUrl;
   int waitTimeSeconds = 20;
   int parallelism = 1;
+  int maxNumberOfMessages = 10;
+  String awsAccessKeyId;
+  String awsSecretAccessKey;
+  String awsStsRoleArn;
+  String awsStsRegion = "us-east-1";
 
   public void setQueueUrl(String queueUrl) {
     this.queueUrl = queueUrl;
@@ -38,6 +43,14 @@ final public class ZipkinSQSCollectorProperties {
     return waitTimeSeconds;
   }
 
+  public void setMaxNumberOfMessages(int maxNumberOfMessages) {
+    this.maxNumberOfMessages = maxNumberOfMessages;
+  }
+
+  public int getMaxNumberOfMessages() {
+    return this.maxNumberOfMessages;
+  }
+
   public void setParallelism(int parallelism) {
     this.parallelism = parallelism;
   }
@@ -46,10 +59,35 @@ final public class ZipkinSQSCollectorProperties {
     return parallelism;
   }
 
+  public void setAwsAccessKeyId(String awsAccessKeyId) {
+    this.awsAccessKeyId = awsAccessKeyId;
+  }
+
+  public String getAwsAccessKeyId() {
+    return this.awsAccessKeyId;
+  }
+
+  public void setAwsSecretAccessKey(String awsSecretAccessKey) {
+    this.awsSecretAccessKey = awsSecretAccessKey;
+  }
+
+  public String getAwsSecretAccessKey() {
+    return this.awsSecretAccessKey;
+  }
+
+  public void setAwsStsRoleArn(String awsStsRoleArn) {
+    this.awsStsRoleArn = awsStsRoleArn;
+  }
+
+  public String getAwsStsRoleArn() {
+    return this.awsStsRoleArn;
+  }
+
   public SQSCollector.Builder toBuilder() {
     return SQSCollector.builder()
         .queueUrl(queueUrl)
         .parallelism(parallelism)
-        .waitTimeSeconds(waitTimeSeconds);
+        .waitTimeSeconds(waitTimeSeconds)
+        .maxNumberOfMessages(maxNumberOfMessages);
   }
 }

--- a/autoconfigure/collector-sqs/src/main/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCredentialsAutoConfiguration.java
+++ b/autoconfigure/collector-sqs/src/main/java/zipkin/autoconfigure/collector/sqs/ZipkinSQSCredentialsAutoConfiguration.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.collector.sqs;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Configuration
+@EnableConfigurationProperties(ZipkinSQSCollectorProperties.class)
+@Conditional(ZipkinSQSCollectorAutoConfiguration.SQSSetCondition.class)
+public class ZipkinSQSCredentialsAutoConfiguration {
+
+  /** Setup {@link AWSSecurityTokenService} client an IAM role to assume is given. */
+  @Bean
+  @ConditionalOnMissingBean
+  @Conditional(STSSetCondition.class)
+  AWSSecurityTokenService securityTokenService(ZipkinSQSCollectorProperties properties) {
+    return AWSSecurityTokenServiceClientBuilder.standard()
+        .withCredentials(getDefaultCredentialsProvider(properties))
+        .withRegion(properties.awsStsRegion)
+        .build();
+  }
+
+  @Autowired(required = false)
+  private AWSSecurityTokenService securityTokenService;
+
+  /** By default, get credentials from the {@link DefaultAWSCredentialsProviderChain */
+  @Bean
+  @ConditionalOnMissingBean
+  AWSCredentialsProvider credentialsProvider(ZipkinSQSCollectorProperties properties) {
+    if (securityTokenService != null) {
+      return new STSAssumeRoleSessionCredentialsProvider.Builder(properties.awsStsRoleArn, "zipkin-server")
+          .withStsClient(securityTokenService)
+          .build();
+    } else {
+      return getDefaultCredentialsProvider(properties);
+    }
+  }
+
+  private static AWSCredentialsProvider getDefaultCredentialsProvider(ZipkinSQSCollectorProperties properties) {
+    AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
+
+    // Create credentials provider from ID and secret if given.
+    if (!isNullOrEmpty(properties.awsAccessKeyId) && !isNullOrEmpty(properties.awsSecretAccessKey)) {
+      provider = new AWSStaticCredentialsProvider(
+          new BasicAWSCredentials(properties.awsAccessKeyId, properties.awsSecretAccessKey));
+    }
+
+    return provider;
+  }
+
+  private static boolean isNullOrEmpty(String value) {
+    return (value == null || value.equals(""));
+  }
+
+
+  /**
+   * This condition passes when {@link ZipkinSQSCollectorProperties#getAwsStsRoleArn()} is set to
+   * non-empty.
+   *
+   * <p>This is here because the yaml defaults this property to empty like this, and spring-boot
+   * doesn't have an option to treat empty properties as unset.
+   *
+   * <pre>{@code
+   * aws-sts-role-arn: ${SQS_AWS_STS_ROLE_ARN:}
+   * }</pre>
+   */
+  static final class STSSetCondition extends SpringBootCondition {
+
+    private static final String PROPERTY_NAME = "zipkin.collector.sqs.aws-sts-role-arn";
+
+    @Override public ConditionOutcome getMatchOutcome(ConditionContext context,
+        AnnotatedTypeMetadata a) {
+
+      String queueUrl = context.getEnvironment().getProperty(PROPERTY_NAME);
+
+      return isEmpty(queueUrl) ?
+          ConditionOutcome.noMatch(PROPERTY_NAME + " isn't set") :
+          ConditionOutcome.match();
+    }
+
+    private static boolean isEmpty(String s) {
+      return s == null || s.isEmpty();
+    }
+  }
+}

--- a/autoconfigure/collector-sqs/src/main/resources/META-INF/spring.factories
+++ b/autoconfigure/collector-sqs/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-zipkin.autoconfigure.collector.sqs.ZipkinSQSCollectorAutoConfiguration
+zipkin.autoconfigure.collector.sqs.ZipkinSQSCollectorAutoConfiguration,\
+zipkin.autoconfigure.collector.sqs.ZipkinSQSCredentialsAutoConfiguration


### PR DESCRIPTION
Ran into a problem recently where the AWS SQS async callbacks were not being called when a queue was empty.  The net result is that the consumers stop consuming and require a server restart to kick them off again. After debugging this for a while I scrapped the async handler and resorted to using the synchronous API.

This PR also adds the ability to assume roles in AWS using the STS APIs.   All configuration changes for assume role authentication only effect the auto configuration library in a backwards compatible way.

/cc @devinsba @adriancole @bijnagte