### PR TITLE
Add server build, module build and bump upstream versions

### DIFF
--- a/autoconfigure/collector-sqs/pom.xml
+++ b/autoconfigure/collector-sqs/pom.xml
@@ -48,4 +48,42 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- Import dependency management from Spring Boot -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <layout>MODULE</layout>
+          <classifier>module</classifier>
+          <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
+          <excludeGroupIds>io.zipkin.java,org.springframework.boot,org.springframework,commons-codec,com.fasterxml.jackson.core,com.fasterxml.jackson.dataformat,org.apache.httpcomponents,commons-logging,joda-time,software.amazon.ion</excludeGroupIds>
+          <!-- already packaged in zipkin-server -->
+          <excludeArtifactIds>aws-java-sdk-core,aws-java-sdk-sts,jmespath-java</excludeArtifactIds>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
 
-    <zipkin.version>1.19.2</zipkin.version>
+    <zipkin.version>1.19.3</zipkin.version>
     <zipkin-reporter.version>0.6.12</zipkin-reporter.version>
 
     <slf4j.version>1.7.22</slf4j.version>


### PR DESCRIPTION
Copied module build config from here: https://github.com/openzipkin/zipkin/issues/1219.  Besides building things and reviewing the contents of the module JAR I haven't actually tested it any further.  Once the snapshots are deployed I can setup a Docker build as described in the ticket and test it out end to end.
