### PR TITLE
Makes circleci use maven wrapper and forces retrolambda to fork

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,8 @@ dependencies:
     - ./build-support/go-offline.sh
 
 test:
+  override:
+    - ./mvnw integration-test
   post:
     # parameters used during release
     # allocate commits to CI, not the owner of the deploy key

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.1</version>
         <executions>
           <execution>
             <goals>
@@ -226,7 +226,7 @@
             </goals>
             <configuration>
               <target>${main.java.version}</target>
-              <fork>false</fork>
+              <fork>true</fork>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Before, circleci's test phase didn't use the maven wrapper which was
inconsistent with other phases.

Also, retrolambda wasn't forking and this caused some spurious issues
attempting to backport lambdas.

See https://github.com/openzipkin/brave/pull/377