### PR TITLE
Adds support for json encoding, notably zipkin2 format

### DIFF
--- a/aws-junit/src/main/java/zipkin/junit/aws/AmazonSQSRule.java
+++ b/aws-junit/src/main/java/zipkin/junit/aws/AmazonSQSRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,6 +30,7 @@ import org.elasticmq.rest.sqs.SQSRestServerBuilder;
 import org.junit.rules.ExternalResource;
 import zipkin.Codec;
 import zipkin.Span;
+import zipkin.SpanDecoder;
 
 import static java.util.Collections.singletonList;
 
@@ -136,7 +137,6 @@ public class AmazonSQSRule extends ExternalResource {
 
   private static List<Span> fromBase64(String base64) {
     byte[] bytes = Base64.decode(base64);
-    return Codec.THRIFT.readSpans(bytes);
+    return SpanDecoder.DETECTING_DECODER.readSpans(bytes);
   }
-
 }

--- a/collector-kinesis/src/main/java/zipkin/collector/kinesis/KinesisSpanProcessor.java
+++ b/collector-kinesis/src/main/java/zipkin/collector/kinesis/KinesisSpanProcessor.java
@@ -18,12 +18,10 @@ import com.amazonaws.services.kinesis.clientlibrary.types.InitializationInput;
 import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
 import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownInput;
 import com.amazonaws.services.kinesis.model.Record;
-import java.util.ArrayList;
-import java.util.List;
-import zipkin.Codec;
 import zipkin.collector.Collector;
-import zipkin.internal.Nullable;
 import zipkin.storage.Callback;
+
+import static zipkin.SpanDecoder.DETECTING_DECODER;
 
 public class KinesisSpanProcessor implements IRecordProcessor {
 
@@ -40,7 +38,7 @@ public class KinesisSpanProcessor implements IRecordProcessor {
   @Override
   public void processRecords(ProcessRecordsInput processRecordsInput) {
     for (Record record : processRecordsInput.getRecords()) {
-      collector.acceptSpans(record.getData().array(), Codec.THRIFT, Callback.NOOP);
+      collector.acceptSpans(record.getData().array(), DETECTING_DECODER, Callback.NOOP);
     }
   }
 

--- a/collector-sqs/src/main/java/zipkin/collector/sqs/SQSSpanProcessor.java
+++ b/collector-sqs/src/main/java/zipkin/collector/sqs/SQSSpanProcessor.java
@@ -27,12 +27,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import zipkin.Codec;
 import zipkin.Component;
 import zipkin.collector.Collector;
 import zipkin.internal.Nullable;
 import zipkin.storage.Callback;
 
+import static zipkin.SpanDecoder.DETECTING_DECODER;
 
 final class SQSSpanProcessor implements Runnable, Component {
 
@@ -101,7 +101,7 @@ final class SQSSpanProcessor implements Runnable, Component {
       final String deleteId = String.valueOf(count++);
       try {
         byte[] spans = Base64.decode(message.getBody());
-        collector.acceptSpans(spans, Codec.THRIFT, new Callback<Void>() {
+        collector.acceptSpans(spans, DETECTING_DECODER, new Callback<Void>() {
           @Override public void onSuccess(@Nullable Void value) {
             toDelete.add(new DeleteMessageBatchRequestEntry(deleteId, message.getReceiptHandle()));
           }

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
 
-    <zipkin.version>1.29.4</zipkin.version>
+    <zipkin.version>1.30.1</zipkin.version>
     <zipkin-reporter.version>1.0.1</zipkin-reporter.version>
 
     <slf4j.version>1.7.25</slf4j.version>

--- a/sender-kinesis/src/main/java/zipkin/reporter/kinesis/KinesisSender.java
+++ b/sender-kinesis/src/main/java/zipkin/reporter/kinesis/KinesisSender.java
@@ -49,6 +49,7 @@ public abstract class KinesisSender extends LazyCloseable<AmazonKinesisAsync> im
   public static Builder builder() {
     return new AutoValue_KinesisSender.Builder()
         .credentialsProvider(new DefaultAWSCredentialsProviderChain())
+        .encoding(Encoding.THRIFT)
         .messageMaxBytes(1024 * 1024); // 1MB Kinesis limit.
   }
 
@@ -68,6 +69,9 @@ public abstract class KinesisSender extends LazyCloseable<AmazonKinesisAsync> im
     /** Maximum size of a message. Kinesis max message size is 1MB */
     Builder messageMaxBytes(int messageMaxBytes);
 
+    /** Allows you to change to json format. Default is thrift */
+    Builder encoding(Encoding encoding);
+
     KinesisSender build();
   }
 
@@ -82,6 +86,8 @@ public abstract class KinesisSender extends LazyCloseable<AmazonKinesisAsync> im
   // Needed to be able to overwrite for tests
   @Nullable
   abstract EndpointConfiguration endpointConfiguration();
+
+  abstract Builder toBuilder();
 
   private final AtomicBoolean closeCalled = new AtomicBoolean(false);
 
@@ -129,13 +135,8 @@ public abstract class KinesisSender extends LazyCloseable<AmazonKinesisAsync> im
   }
 
   @Override
-  public Encoding encoding() {
-    return Encoding.THRIFT;
-  }
-
-  @Override
   public int messageSizeInBytes(List<byte[]> list) {
-    return Encoding.THRIFT.listSizeInBytes(list);
+    return encoding().listSizeInBytes(list);
   }
 
   @Override

--- a/sender-sqs/src/main/java/zipkin/reporter/sqs/SQSSender.java
+++ b/sender-sqs/src/main/java/zipkin/reporter/sqs/SQSSender.java
@@ -57,6 +57,7 @@ public abstract class SQSSender extends LazyCloseable<AmazonSQSAsync> implements
   public static Builder builder() {
     return new AutoValue_SQSSender.Builder()
         .credentialsProvider(new DefaultAWSCredentialsProviderChain())
+        .encoding(Encoding.THRIFT)
         .messageMaxBytes(256 * 1024); // 256KB SQS limit.
   }
 
@@ -74,6 +75,9 @@ public abstract class SQSSender extends LazyCloseable<AmazonSQSAsync> implements
 
     /** Maximum size of a message. SQS max message size is 256KB including attributes. */
     Builder messageMaxBytes(int messageMaxBytes);
+
+    /** Allows you to change to json format. Default is thrift */
+    Builder encoding(Encoding encoding);
 
     SQSSender build();
   }
@@ -103,10 +107,6 @@ public abstract class SQSSender extends LazyCloseable<AmazonSQSAsync> implements
   @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
     int listSize = encoding().listSizeInBytes(encodedSpans);
     return (listSize + 2) * 4 / 3; // account for base64 encoding
-  }
-
-  @Override public Encoding encoding() {
-    return Encoding.THRIFT;
   }
 
   @Override public void sendSpans(List<byte[]> list, Callback callback) {


### PR DESCRIPTION
Before the AWS transports only supported thrift encoding. This adds json
support, which will notably be used for zipkin2 format.

This uses the recently released detecting decoder to support the new
Span2 format defined in https://github.com/openzipkin/zipkin/issues/1499