### PR TITLE
Working XRayUDPReporter and STORAGE_TYPE xray

### DIFF
--- a/autoconfigure/collector-kinesis/pom.xml
+++ b/autoconfigure/collector-kinesis/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-autoconfigure</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -66,7 +66,7 @@
           <classifier>module</classifier>
           <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
           <excludeGroupIds>
-            io.zipkin.java,org.springframework.boot,org.springframework,commons-codec,com.fasterxml.jackson.core,com.fasterxml.jackson.dataformat,org.apache.httpcomponents,commons-logging,joda-time,software.amazon.ion
+            io.zipkin.java,io.zipkin.zipkin2,org.springframework.boot,org.springframework,commons-codec,com.fasterxml.jackson.core,com.fasterxml.jackson.dataformat,org.apache.httpcomponents,commons-logging,joda-time,software.amazon.ion
           </excludeGroupIds>
           <!-- already packaged in zipkin-server -->
           <excludeArtifactIds>aws-java-sdk-core,aws-java-sdk-sts,jmespath-java</excludeArtifactIds>

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-autoconfigure</artifactId>
@@ -35,6 +35,7 @@
     <module>collector-sqs</module>
     <module>sparkstreaming-stream-kinesis</module>
     <module>collector-kinesis</module>
+    <module>storage-xray</module>
   </modules>
 
   <dependencies>
@@ -42,6 +43,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
       <version>${spring-boot.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/autoconfigure/sparkstreaming-stream-kinesis/pom.xml
+++ b/autoconfigure/sparkstreaming-stream-kinesis/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>zipkin-autoconfigure</artifactId>
         <groupId>io.zipkin.aws</groupId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/autoconfigure/storage-xray/README.md
+++ b/autoconfigure/storage-xray/README.md
@@ -1,0 +1,49 @@
+# autoconfigure-storage-xray
+
+## Overview
+
+This is a Spring Boot [AutoConfiguration](http://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-auto-configuration.html)
+module that can be added to a [Zipkin Server](https://github.com/openzipkin/zipkin/tree/master/zipkin-server) 
+deployment to send Spans to Amazon XRay.
+
+This currently only supports sending to an XRay UDP daemon, not reading back spans from the service.
+Internally this module wraps the [XRayUDPStorage](https://github.com/openzipkin/zipkin-aws/tree/master/storage-xray-udp)
+and exposes configuration options through environment variables.
+
+## Experimental
+* Note: This is currently experimental! *
+* Note: This requires reporters send 128-bit trace IDs, with the first 32bits as epoch seconds *
+* Check https://github.com/openzipkin/b3-propagation/issues/6 for tracers that support epoch128 trace IDs
+
+## Usage
+
+Download the module from [TODO] link and extract it to a directory relative to the
+Zipkin Server jar.
+
+### Configuration
+
+Configuration can be applied either through environment variables or an external Zipkin
+configuration file.  The module includes default configuration that can be used as a 
+[reference](https://github.com/openzipkin/zipkin-aws/tree/master/autoconfigure/storage-xray/src/main/resources/zipkin-server-xray.yml)
+for users that prefer a file based approach.
+
+##### Environment Variables
+
+- `AWS_XRAY_DAEMON_ADDRESS` The UDP endpoint to send spans to. _Defaults to localhost:2000_
+
+### Running
+
+```bash
+STORAGE_TYPE=xray
+java -Dloader.path=xray -Dspring.profiles.active=xray -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher
+```
+
+### Testing
+
+Once your storage is enabled, verify it is running:
+```bash
+$ curl -s localhost:9411/health|jq .zipkin.XrayStorage
+{
+  "status": "UP"
+}
+```

--- a/autoconfigure/storage-xray/pom.xml
+++ b/autoconfigure/storage-xray/pom.xml
@@ -15,16 +15,15 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-
   <parent>
-    <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-autoconfigure</artifactId>
+    <groupId>io.zipkin.aws</groupId>
     <version>0.8.0-SNAPSHOT</version>
   </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>zipkin-autoconfigure-collector-sqs</artifactId>
-  <name>Auto Configuration: SQS Collector</name>
+  <artifactId>zipkin-autoconfigure-storage-xray</artifactId>
+  <name>Auto Configuration: XRay Storage</name>
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
@@ -33,19 +32,12 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-collector-sqs</artifactId>
-      <version>${project.version}</version>
+      <artifactId>zipkin-storage-xray-udp</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
-      <version>${aws-java-sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-aws-junit</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 
@@ -66,7 +58,9 @@
           <layout>MODULE</layout>
           <classifier>module</classifier>
           <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
-          <excludeGroupIds>io.zipkin.java,io.zipkin.zipkin2,org.springframework.boot,org.springframework,commons-codec,com.fasterxml.jackson.core,com.fasterxml.jackson.dataformat,org.apache.httpcomponents,commons-logging,joda-time,software.amazon.ion</excludeGroupIds>
+          <excludeGroupIds>
+            io.zipkin.java,io.zipkin.zipkin2,org.springframework.boot,org.springframework,commons-codec,com.fasterxml.jackson.core,com.fasterxml.jackson.dataformat,org.apache.httpcomponents,commons-logging,joda-time,software.amazon.ion
+          </excludeGroupIds>
           <!-- already packaged in zipkin-server -->
           <excludeArtifactIds>aws-java-sdk-core,aws-java-sdk-sts,jmespath-java</excludeArtifactIds>
         </configuration>

--- a/autoconfigure/storage-xray/src/main/java/zipkin/autoconfigure/storage/xray/ZipkinXRayStorageAutoConfiguration.java
+++ b/autoconfigure/storage-xray/src/main/java/zipkin/autoconfigure/storage/xray/ZipkinXRayStorageAutoConfiguration.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.xray;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin.internal.V2StorageComponent;
+import zipkin.storage.StorageComponent;
+import zipkin2.storage.xray_udp.XRayUDPStorage;
+
+@Configuration
+@EnableConfigurationProperties(zipkin.autoconfigure.storage.xray.ZipkinXRayStorageProperties.class)
+@ConditionalOnProperty(name = "zipkin.storage.type", havingValue = "xray")
+@ConditionalOnMissingBean(StorageComponent.class)
+public class ZipkinXRayStorageAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  V2StorageComponent storage(
+      zipkin.autoconfigure.storage.xray.ZipkinXRayStorageProperties properties,
+      @Value("${zipkin.storage.strict-trace-id:true}") boolean strictTraceId) {
+    XRayUDPStorage result = properties.toBuilder().strictTraceId(strictTraceId).build();
+    return V2StorageComponent.create(result);
+  }
+
+  @Bean XRayUDPStorage v2Storage(V2StorageComponent component) {
+    return (XRayUDPStorage) component.delegate();
+  }
+}

--- a/autoconfigure/storage-xray/src/main/java/zipkin/autoconfigure/storage/xray/ZipkinXRayStorageProperties.java
+++ b/autoconfigure/storage-xray/src/main/java/zipkin/autoconfigure/storage/xray/ZipkinXRayStorageProperties.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.autoconfigure.storage.xray;
+
+import java.io.Serializable;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import zipkin2.storage.xray_udp.XRayUDPStorage;
+
+@ConfigurationProperties("zipkin.storage.xray")
+public class ZipkinXRayStorageProperties implements Serializable { // for Spark jobs
+  private static final long serialVersionUID = 0L;
+
+  /** Amazon X-Ray Daemon UDP daemon address; defaults to localhost:2000 */
+  private String daemonAddress;
+
+  public String getDaemonAddress() {
+    return daemonAddress;
+  }
+
+  public void setDaemonAddress(String daemonAddress) {
+    this.daemonAddress = "".equals(daemonAddress) ? null : daemonAddress;
+  }
+
+  public XRayUDPStorage.Builder toBuilder() {
+    XRayUDPStorage.Builder builder = XRayUDPStorage.newBuilder();
+    if (daemonAddress != null) builder.address(daemonAddress);
+    return builder;
+  }
+}

--- a/autoconfigure/storage-xray/src/main/resources/META-INF/spring.factories
+++ b/autoconfigure/storage-xray/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+zipkin.autoconfigure.storage.xray.ZipkinXRayStorageAutoConfiguration

--- a/autoconfigure/storage-xray/src/main/resources/zipkin-server-xray.yml
+++ b/autoconfigure/storage-xray/src/main/resources/zipkin-server-xray.yml
@@ -1,0 +1,6 @@
+# When enabled, this allows shorter env properties (ex -Dspring.profiles.active=xray)
+zipkin:
+  storage:
+    xray:
+      # Amazon X-Ray Daemon UDP daemon address; defaults to localhost:2000
+      daemon-address: ${AWS_XRAY_DAEMON_ADDRESS:}

--- a/autoconfigure/storage-xray/src/test/java/zipkin2/storage/xray/ZipkinXRayStorageAutoConfigurationTest.java
+++ b/autoconfigure/storage-xray/src/test/java/zipkin2/storage/xray/ZipkinXRayStorageAutoConfigurationTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.xray;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import zipkin.autoconfigure.storage.xray.ZipkinXRayStorageAutoConfiguration;
+import zipkin.autoconfigure.storage.xray.ZipkinXRayStorageProperties;
+import zipkin2.storage.xray_udp.XRayUDPStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+
+public class ZipkinXRayStorageAutoConfigurationTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  AnnotationConfigApplicationContext context;
+
+  @After public void close() {
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  @Test public void doesntProvideStorageComponent_whenStorageTypeNotXRay() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:elasticsearch");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinXRayStorageAutoConfiguration.class);
+    context.refresh();
+
+    thrown.expect(NoSuchBeanDefinitionException.class);
+    context.getBean(XRayUDPStorage.class);
+  }
+
+  @Test public void providesStorageComponent_whenStorageTypeXRay() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context, "zipkin.storage.type:xray");
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinXRayStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(XRayUDPStorage.class)).isNotNull();
+  }
+
+  @Test public void canOverrideProperty_daemonAddress() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:xray",
+        "zipkin.storage.xray.daemon-address:localhost:3000"
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinXRayStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinXRayStorageProperties.class).getDaemonAddress())
+        .isEqualTo("localhost:3000");
+  }
+}

--- a/collector-kinesis/pom.xml
+++ b/collector-kinesis/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/collector-sqs/pom.xml
+++ b/collector-sqs/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.aws</groupId>
   <artifactId>zipkin-aws-parent</artifactId>
-  <version>0.7.2-SNAPSHOT</version>
+  <version>0.8.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -30,6 +30,8 @@
     <module>sparkstreaming-stream-kinesis</module>
     <module>collector-kinesis</module>
     <module>sender-kinesis</module>
+    <module>storage-xray-udp</module>
+    <module>reporter-xray-udp</module>
   </modules>
 
   <properties>
@@ -45,7 +47,7 @@
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
 
     <zipkin.version>2.2.1</zipkin.version>
-    <zipkin-reporter2.version>2.1.2</zipkin-reporter2.version>
+    <zipkin-reporter2.version>2.1.3</zipkin-reporter2.version>
 
     <slf4j.version>1.7.25</slf4j.version>
 
@@ -140,6 +142,11 @@
         <artifactId>zipkin-reporter</artifactId>
         <version>${zipkin-reporter2.version}</version>
         <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-storage-xray-udp</artifactId>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/reporter-xray-udp/README.md
+++ b/reporter-xray-udp/README.md
@@ -1,0 +1,3 @@
+# reporter-xray-udp
+
+This sends json to XRay's daemon via UDP

--- a/reporter-xray-udp/pom.xml
+++ b/reporter-xray-udp/pom.xml
@@ -15,44 +15,36 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
-  <modelVersion>4.0.0</modelVersion>
-
   <parent>
-    <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
+    <groupId>io.zipkin.aws</groupId>
     <version>0.8.0-SNAPSHOT</version>
   </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>zipkin-aws-junit</artifactId>
-  <name>Zipkin AWS JUnit Rules</name>
+  <artifactId>zipkin-reporter-xray-udp</artifactId>
+  <name>Zipkin Reporter: AWS XRay UDP</name>
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- Test use Java8 -->
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>
-
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sqs</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-storage-xray-udp</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-reporter</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.elasticmq</groupId>
-      <artifactId>elasticmq-server_2.12</artifactId>
-      <version>0.13.8</version>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
-
   </dependencies>
 </project>

--- a/reporter-xray-udp/src/main/java/zipkin2/reporter/xray_udp/XRayUDPReporter.java
+++ b/reporter-xray-udp/src/main/java/zipkin2/reporter/xray_udp/XRayUDPReporter.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.xray_udp;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import zipkin2.Call;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+import zipkin2.storage.xray_udp.XRayUDPStorage;
+
+public class XRayUDPReporter implements Reporter<Span>, Closeable {
+  static final Logger logger = Logger.getLogger(XRayUDPReporter.class.getName());
+
+  /**
+   * Creates a reporter defaulting to the env variable "AWS_XRAY_DAEMON_ADDRESS" or
+   * "localhost:2000"
+   */
+  public static Reporter<Span> create() {
+    return new XRayUDPReporter(XRayUDPStorage.newBuilder().build());
+  }
+
+  public static Reporter<Span> create(String address) {
+    return new XRayUDPReporter(XRayUDPStorage.newBuilder().address(address).build());
+  }
+
+  final XRayUDPStorage delegate;
+
+  XRayUDPReporter(XRayUDPStorage delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public void close() throws IOException {
+    delegate.close();
+  }
+
+  @Override public void report(Span span) {
+    Call<Void> call;
+    try {
+      call = delegate.accept(Collections.singletonList(span));
+    } catch (RuntimeException e) {
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "couldn't convert span " + span + " into a UDP message", e);
+      }
+      return;
+    }
+    try {
+      call.execute();
+    } catch (IOException | RuntimeException e) {
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "couldn't send UDP message", e);
+      }
+    }
+  }
+
+  @Override public String toString() {
+    return "XRayUDPReporter(" + delegate + ")";
+  }
+}

--- a/reporter-xray-udp/src/test/java/zipkin2/reporter/xray_udp/XRayUDPReporterTest.java
+++ b/reporter-xray-udp/src/test/java/zipkin2/reporter/xray_udp/XRayUDPReporterTest.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.xray_udp;
+
+public class XRayUDPReporterTest {
+}

--- a/sender-kinesis/pom.xml
+++ b/sender-kinesis/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/sender-sqs/pom.xml
+++ b/sender-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.7.2-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-sqs</artifactId>

--- a/sparkstreaming-stream-kinesis/pom.xml
+++ b/sparkstreaming-stream-kinesis/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>zipkin-aws-parent</artifactId>
         <groupId>io.zipkin.aws</groupId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/storage-xray-udp/README.md
+++ b/storage-xray-udp/README.md
@@ -1,0 +1,3 @@
+# storage-xray-udp
+
+This sends json to XRay's daemon via UDP

--- a/storage-xray-udp/pom.xml
+++ b/storage-xray-udp/pom.xml
@@ -15,44 +15,26 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
-  <modelVersion>4.0.0</modelVersion>
-
   <parent>
-    <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
+    <groupId>io.zipkin.aws</groupId>
     <version>0.8.0-SNAPSHOT</version>
   </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>zipkin-aws-junit</artifactId>
-  <name>Zipkin AWS JUnit Rules</name>
+  <artifactId>zipkin-storage-xray-udp</artifactId>
+  <name>Zipkin Storage: AWS XRay UDP</name>
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- Test use Java8 -->
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
   <dependencies>
-
+    <!-- TODO: consider shading as it can make this 3rd party dep-free -->
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sqs</artifactId>
+      <groupId>com.squareup.moshi</groupId>
+      <artifactId>moshi</artifactId>
+      <version>1.5.0</version>
     </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.elasticmq</groupId>
-      <artifactId>elasticmq-server_2.12</artifactId>
-      <version>0.13.8</version>
-    </dependency>
-
   </dependencies>
 </project>

--- a/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/BaseCall.java
+++ b/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/BaseCall.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.xray_udp;
+
+import java.io.IOException;
+import zipkin2.Call;
+import zipkin2.Callback;
+
+// copy/pasted from zipkin-reporter temporarily to avoid adding a dependency
+abstract class BaseCall<V> extends Call<V> {
+  volatile boolean canceled;
+  boolean executed;
+
+  @Override public final V execute() throws IOException {
+    synchronized (this) {
+      if (this.executed) throw new IllegalStateException("Already Executed");
+      this.executed = true;
+    }
+
+    if (isCanceled()) {
+      throw new IOException("Canceled");
+    } else {
+      return this.doExecute();
+    }
+  }
+
+  protected abstract V doExecute() throws IOException;
+
+  @Override public final void enqueue(Callback<V> callback) {
+    synchronized (this) {
+      if (this.executed) throw new IllegalStateException("Already Executed");
+      this.executed = true;
+    }
+
+    if (isCanceled()) {
+      callback.onError(new IOException("Canceled"));
+    } else {
+      this.doEnqueue(callback);
+    }
+  }
+
+  abstract void doEnqueue(Callback<V> callback);
+
+  @Override public final void cancel() {
+    this.canceled = true;
+  }
+
+  @Override public final boolean isCanceled() {
+    return this.canceled;
+  }
+}

--- a/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/UDPMessageEncoder.java
+++ b/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/UDPMessageEncoder.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.xray_udp;
+
+import com.squareup.moshi.JsonWriter;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import okio.Buffer;
+import zipkin2.Span;
+
+final class UDPMessageEncoder {
+  static final Logger logger = Logger.getLogger(UDPMessageEncoder.class.getName());
+
+  static byte[] encode(Span span) {
+    try {
+      return doEncode(span);
+    } catch (IOException e) {
+      throw new AssertionError(e); // encoding error is a programming bug
+    }
+  }
+
+  static byte[] doEncode(Span span) throws IOException {
+    if (span.traceId().length() != 32) { // TODO: also sanity check first 8 chars are epoch seconds
+      if (logger.isLoggable(Level.FINE)) {
+        logger.fine("span reported without a 128-bit trace ID" + span);
+      }
+      throw new IllegalStateException("Change the tracer to use 128-bit trace IDs");
+    }
+    Buffer buffer = new Buffer();
+    buffer.writeUtf8("{\"format\": \"json\", \"version\": 1}\n");
+    JsonWriter writer = JsonWriter.of(buffer);
+    writer.beginObject();
+    writer.name("trace_id").value(new StringBuilder()
+        .append("1-")
+        .append(span.traceId(), 0, 8)
+        .append('-')
+        .append(span.traceId(), 8, 32).toString());
+    if (span.parentId() != null) writer.name("parent_id").value(span.parentId());
+    writer.name("id").value(span.id());
+    if (span.kind() == null
+        || span.kind() != Span.Kind.SERVER && span.kind() != Span.Kind.CONSUMER) {
+      writer.name("type").value("subsegment");
+      if (span.kind() != null) writer.name("namespace").value("remote");
+    }
+    writer.name("name").value(span.localServiceName());
+    if (span.timestamp() != null) {
+      writer.name("start_time").value(span.timestamp() / 1_000_000.0D);
+      if (span.duration() != null) {
+        writer.name("end_time").value((span.timestamp() + span.duration()) / 1_000_000.0D);
+      } else {
+        writer.name("in_progress").value(true);
+      }
+    }
+
+    String httpRequestMethod = null, httpRequestUrl = null;
+    Integer httpResponseStatus = null;
+    boolean http = false;
+
+    Map<String, String> annotations = new LinkedHashMap<>();
+    Map<String, String> metadata = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : span.tags().entrySet()) {
+      if (entry.getKey().startsWith("http.")) {
+        http = true;
+        switch (entry.getKey()) {
+          case "http.method":
+            httpRequestMethod = entry.getValue();
+            continue;
+          case "http.url":
+            httpRequestUrl = entry.getValue();
+            continue;
+          case "http.status_code":
+            httpResponseStatus = Integer.parseInt(entry.getValue());
+            continue;
+        }
+      }
+      String key = entry.getKey().replace('.', '_');
+      if (entry.getValue().length() < 250) {
+        annotations.put(key, entry.getValue());
+      } else {
+        metadata.put(key, entry.getValue());
+      }
+    }
+
+    if (http) {
+      if (httpRequestMethod == null) {
+        httpRequestMethod = span.name(); // TODO validate
+      }
+      writer.name("http");
+      writer.beginObject();
+      if (httpRequestMethod != null || httpRequestUrl != null) {
+        writer.name("request");
+        writer.beginObject();
+        if (httpRequestMethod != null) {
+          writer.name("method").value(httpRequestMethod.toUpperCase());
+        }
+        if (httpRequestUrl != null) {
+          writer.name("url").value(httpRequestUrl);
+        }
+        writer.endObject();
+      }
+      if (httpResponseStatus != null) {
+        writer.name("response");
+        writer.beginObject();
+        writer.name("status").value(httpResponseStatus);
+        writer.endObject();
+      }
+      writer.endObject();
+    }
+
+    if (!annotations.isEmpty()) {
+      writer.name("annotations");
+      writer.beginObject();
+      if (httpRequestMethod != null && span.name() != null && !httpRequestMethod.equals(
+          span.name())) {
+        writer.name("operation").value(span.name());
+      }
+      for (Map.Entry<String, String> annotation : annotations.entrySet()) {
+        writer.name(annotation.getKey()).value(annotation.getValue());
+      }
+      writer.endObject();
+    }
+    if (!metadata.isEmpty()) {
+      writer.name("metadata");
+      writer.beginObject();
+      for (Map.Entry<String, String> metadatum : metadata.entrySet()) {
+        writer.name(metadatum.getKey()).value(metadatum.getValue());
+      }
+      writer.endObject();
+    }
+    writer.endObject();
+    return buffer.readByteArray();
+  }
+}

--- a/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/XRayUDPStorage.java
+++ b/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/XRayUDPStorage.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.xray_udp;
+
+import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import zipkin2.Call;
+import zipkin2.Callback;
+import zipkin2.DependencyLink;
+import zipkin2.Span;
+import zipkin2.storage.QueryRequest;
+import zipkin2.storage.SpanConsumer;
+import zipkin2.storage.SpanStore;
+import zipkin2.storage.StorageComponent;
+
+@AutoValue
+public abstract class XRayUDPStorage extends StorageComponent implements SpanStore, SpanConsumer {
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder extends StorageComponent.Builder {
+    boolean strictTraceId = true;
+    String address;
+
+    /** {@inheritDoc} */
+    @Override public Builder strictTraceId(boolean strictTraceId) {
+      this.strictTraceId = strictTraceId;
+      return this;
+    }
+
+    /** Defaults to the env variable AWS_XRAY_DAEMON_ADDRESS or localhost:2000 */
+    public Builder address(String address) {
+      if (address == null) throw new IllegalArgumentException("address == null");
+      this.address = address;
+      return this;
+    }
+
+    @Override public XRayUDPStorage build() {
+      String address = this.address;
+      if (address == null) {
+        address = System.getenv("AWS_XRAY_DAEMON_ADDRESS");
+        if (address == null || address.isEmpty()) {
+          return new AutoValue_XRayUDPStorage(new InetSocketAddress("localhost", 2000));
+        } // otherwise fall through to parse
+      }
+      String[] splitAddress = address.split(":");
+      String host = splitAddress[0];
+      Integer port = null;
+      try {
+        if (splitAddress.length == 2) port = Integer.parseInt(splitAddress[1]);
+      } catch (NumberFormatException ignore) {
+      }
+      return new AutoValue_XRayUDPStorage(new InetSocketAddress(host, port));
+    }
+
+    Builder() {
+    }
+  }
+
+  static final int PACKET_LENGTH = 256 * 1024;
+  static final ThreadLocal<byte[]> BUF = new ThreadLocal<byte[]>() {
+    @Override protected byte[] initialValue() {
+      return new byte[PACKET_LENGTH];
+    }
+  };
+
+  abstract InetSocketAddress address();
+
+  /** get and close are typically called from different threads */
+  volatile boolean provisioned, closeCalled;
+
+  @Memoized DatagramSocket socket() {
+    DatagramSocket result;
+    try {
+      result = new DatagramSocket();
+    } catch (SocketException e) {
+      throw new IllegalStateException(e);
+    }
+    provisioned = true;
+    return result;
+  }
+
+  @Override public SpanStore spanStore() {
+    return this;
+  }
+
+  @Override public SpanConsumer spanConsumer() {
+    return this;
+  }
+
+  @Override public Call<Void> accept(List<Span> spans) {
+    if (closeCalled) throw new IllegalStateException("closed");
+    if (spans.isEmpty()) return Call.create(null);
+
+    int length = spans.size();
+    if (length == 1) { // don't allocate an array for a single span
+      return new UDPCall(Collections.singletonList(UDPMessageEncoder.encode(spans.get(0))));
+    }
+
+    List<byte[]> encoded = new ArrayList<>(length);
+    for (int i = 0; i < length; i++) {
+      encoded.add(UDPMessageEncoder.encode(spans.get(i)));
+    }
+    return new UDPCall(encoded);
+  }
+
+  // Synchronous sending eliminates a risk of lost spans when not closing the reporter.
+  // TODO: benchmark to see if the overhead is ok
+  void send(byte[] message) throws IOException {
+    DatagramPacket packet = new DatagramPacket(BUF.get(), PACKET_LENGTH, address());
+    packet.setData(message);
+    socket().send(packet);
+  }
+
+  class UDPCall extends BaseCall<Void> {
+    private final List<byte[]> messages;
+
+    UDPCall(List<byte[]> messages) {
+      this.messages = messages;
+    }
+
+    @Override protected Void doExecute() throws IOException {
+      for (byte[] message : messages) send(message);
+      return null;
+    }
+
+    @Override protected void doEnqueue(Callback<Void> callback) {
+      try {
+        doExecute();
+        callback.onSuccess(null);
+      } catch (IOException | RuntimeException | Error e) {
+        propagateIfFatal(e);
+        callback.onError(e);
+      }
+    }
+
+    @Override public Call<Void> clone() {
+      return new UDPCall(messages);
+    }
+  }
+
+  @Override public synchronized void close() {
+    if (closeCalled) return;
+    if (provisioned) socket().close();
+    closeCalled = true;
+  }
+
+  @Override public Call<List<List<Span>>> getTraces(QueryRequest queryRequest) {
+    throw new UnsupportedOperationException("This is collector-only at the moment");
+  }
+
+  @Override public Call<List<Span>> getTrace(String s) {
+    throw new UnsupportedOperationException("This is collector-only at the moment");
+  }
+
+  @Override public Call<List<String>> getServiceNames() {
+    throw new UnsupportedOperationException("This is collector-only at the moment");
+  }
+
+  @Override public Call<List<String>> getSpanNames(String s) {
+    throw new UnsupportedOperationException("This is collector-only at the moment");
+  }
+
+  @Override public Call<List<DependencyLink>> getDependencies(long l, long l1) {
+    throw new UnsupportedOperationException("This is collector-only at the moment");
+  }
+
+  XRayUDPStorage() {
+  }
+}

--- a/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/XRayUDPStorageTest.java
+++ b/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/XRayUDPStorageTest.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.xray_udp;
+
+public class XRayUDPStorageTest {
+}


### PR DESCRIPTION
from https://github.com/openzipkin/brave/pull/510

This adds `XRayUDPReporter` which defaults to localhost:2000 or
AWS_XRAY_DAEMON_ADDRESS. This can be used in applications directly or
integrated with a zipkin-server where `STORAGE_TYPE=xray`

Note: this is experimental and makes assumptions about trace ID format:
See openzipkin/b3-propagation#6