### PR TITLE
Ensures X-Ray json has parent_id if type=segment

### DIFF
--- a/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/UDPMessageEncoder.java
+++ b/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/UDPMessageEncoder.java
@@ -51,11 +51,13 @@ final class UDPMessageEncoder {
         .append(span.traceId(), 0, 8)
         .append('-')
         .append(span.traceId(), 8, 32).toString());
-    if (span.parentId() != null) writer.name("parent_id").value(span.parentId());
     writer.name("id").value(span.id());
     if (span.kind() == null
         || span.kind() != Span.Kind.SERVER && span.kind() != Span.Kind.CONSUMER) {
-      writer.name("type").value("subsegment");
+      if (span.parentId() != null) {
+        writer.name("parent_id").value(span.parentId());
+        writer.name("type").value("subsegment");
+      }
       if (span.kind() != null) writer.name("namespace").value("remote");
       // some remote service's name can be null, using null names causes invisible subsegment
       // using "unknown" subsegment name will help to detect missing names

--- a/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/UDPMessageEncoderTest.java
+++ b/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/UDPMessageEncoderTest.java
@@ -44,7 +44,7 @@ public class UDPMessageEncoderTest {
   public void doEncodeClient() throws Exception {
     String target = "{\"format\": \"json\", \"version\": 1}\n"
                     + "{\"trace_id\":\"1-12345678-90abcdef1234567890abcdef\",\"id\":\"1234567890abcdef\","
-                    + "\"type\":\"subsegment\",\"namespace\":\"remote\",\"name\":\"master\"}";
+                    + "\"namespace\":\"remote\",\"name\":\"master\"}";
     Span span = Span
         .newBuilder()
         .kind(Span.Kind.CLIENT)
@@ -64,7 +64,7 @@ public class UDPMessageEncoderTest {
   public void doEncodeSql() throws Exception {
     String target = "{\"format\": \"json\", \"version\": 1}\n"
                     + "{\"trace_id\":\"1-12345678-90abcdef1234567890abcdef\",\"id\":\"1234567890abcdef\","
-                    + "\"type\":\"subsegment\",\"namespace\":\"remote\",\"name\":\"master\","
+                    + "\"namespace\":\"remote\",\"name\":\"master\","
                     + "\"sql\":{\"url\":\"jdbc:test\"}}";
     Span span = Span
         .newBuilder()
@@ -86,7 +86,7 @@ public class UDPMessageEncoderTest {
   public void doEncodeUnkown() throws Exception {
     String target = "{\"format\": \"json\", \"version\": 1}\n"
                     + "{\"trace_id\":\"1-12345678-90abcdef1234567890abcdef\",\"id\":\"1234567890abcdef\","
-                    + "\"type\":\"subsegment\",\"namespace\":\"remote\",\"name\":\"unknown\","
+                    + "\"namespace\":\"remote\",\"name\":\"unknown\","
                     + "\"sql\":{\"url\":\"jdbc:test\"}}";
     Span span = Span
         .newBuilder()
@@ -108,7 +108,7 @@ public class UDPMessageEncoderTest {
   public void doEncodeAws() throws Exception {
     String target = "{\"format\": \"json\", \"version\": 1}\n"
                     + "{\"trace_id\":\"1-12345678-90abcdef1234567890abcdef\",\"id\":\"1234567890abcdef\","
-                    + "\"type\":\"subsegment\",\"namespace\":\"remote\",\"name\":\"unknown\","
+                    + "\"namespace\":\"remote\",\"name\":\"unknown\","
                     + "\"aws\":{\"region\":\"reg1\",\"table_name\":\"table1\"}}";
     Span span = Span
         .newBuilder()


### PR DESCRIPTION
I got the following error from X-Ray agent
```
2017-12-04T15:00:37Z [Error] unprocessed segment: {
  ErrorCode: "MissingParentId",
  Id: "7a0ac3a355fe232e",
  Message: "Invalid subsegment. ErrorCode: MissingParentId, Cause: null"
}
2017-12-04T15:00:37Z [Warn] {"trace_id":"1-7381dc2c-6825ddf77a0ac3a355fe232e","id":"7a0ac3a355fe232e","type":"subsegment","name":"my-service","start_time":1.512399636124057E9,"end_time":1.512399636125315E9,"annotations":{"akka_actor_class":"com.bamtechmedia.opentracing.cinnamon.xray.examples.cinnamon.Greeter","akka_actor_system-message":"Create(None)","component":"akka.actor","span_kind":"akka.actor.system-message.receive"}}
```

The json document seems to have `"type":"subsegment"` but no `parent_id`, which is illegal.

This PR ensures we either write both fields or none of them.