### PR TITLE
Use local service name as X-Ray subsegment name

### DIFF
--- a/autoconfigure/storage-xray/src/main/java/zipkin/autoconfigure/storage/xray/ZipkinXRayStorageProperties.java
+++ b/autoconfigure/storage-xray/src/main/java/zipkin/autoconfigure/storage/xray/ZipkinXRayStorageProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,8 @@ public class ZipkinXRayStorageProperties implements Serializable { // for Spark 
   /** Amazon X-Ray Daemon UDP daemon address; defaults to localhost:2000 */
   private String daemonAddress;
 
+  private boolean useLocalServiceNameWhenRemoteIsMissing;
+
   public String getDaemonAddress() {
     return daemonAddress;
   }
@@ -32,9 +34,18 @@ public class ZipkinXRayStorageProperties implements Serializable { // for Spark 
     this.daemonAddress = "".equals(daemonAddress) ? null : daemonAddress;
   }
 
+  public boolean isUseLocalServiceNameWhenRemoteIsMissing() {
+    return useLocalServiceNameWhenRemoteIsMissing;
+  }
+
+  public void setUseLocalServiceNameWhenRemoteIsMissing(boolean useLocalServiceNameWhenRemoteIsMissing) {
+    this.useLocalServiceNameWhenRemoteIsMissing = useLocalServiceNameWhenRemoteIsMissing;
+  }
+
   public XRayUDPStorage.Builder toBuilder() {
     XRayUDPStorage.Builder builder = XRayUDPStorage.newBuilder();
     if (daemonAddress != null) builder.address(daemonAddress);
+    if (useLocalServiceNameWhenRemoteIsMissing) builder.useLocalServiceNameWhenRemoteIsMissing();
     return builder;
   }
 }

--- a/autoconfigure/storage-xray/src/test/java/zipkin2/storage/xray/ZipkinXRayStorageAutoConfigurationTest.java
+++ b/autoconfigure/storage-xray/src/test/java/zipkin2/storage/xray/ZipkinXRayStorageAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -72,5 +72,32 @@ public class ZipkinXRayStorageAutoConfigurationTest {
 
     assertThat(context.getBean(ZipkinXRayStorageProperties.class).getDaemonAddress())
         .isEqualTo("localhost:3000");
+  }
+
+  @Test public void propertyDefaultValue_useLocalServiceNameWhenMissingRemote() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:xray"
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinXRayStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinXRayStorageProperties.class).isUseLocalServiceNameWhenRemoteIsMissing())
+        .isEqualTo(false);
+  }
+
+  @Test public void canOverrideProperty_useLocalServiceNameWhenMissingRemote() {
+    context = new AnnotationConfigApplicationContext();
+    addEnvironment(context,
+        "zipkin.storage.type:xray",
+        "zipkin.storage.xray.use-local-service-name-when-remote-is-missing:true"
+    );
+    context.register(PropertyPlaceholderAutoConfiguration.class,
+        ZipkinXRayStorageAutoConfiguration.class);
+    context.refresh();
+
+    assertThat(context.getBean(ZipkinXRayStorageProperties.class).isUseLocalServiceNameWhenRemoteIsMissing())
+        .isEqualTo(true);
   }
 }

--- a/storage-xray-udp/pom.xml
+++ b/storage-xray-udp/pom.xml
@@ -42,5 +42,11 @@
       <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.18.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/storage-xray-udp/pom.xml
+++ b/storage-xray-udp/pom.xml
@@ -42,11 +42,5 @@
       <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <version>1.18.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/UDPMessageEncoder.java
+++ b/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/UDPMessageEncoder.java
@@ -46,7 +46,7 @@ final class UDPMessageEncoder {
       // result in the service map displaying services depending on an "unknown" one.
       if (span.remoteServiceName() == null) {
         if ("true".equalsIgnoreCase(System.getenv("AWS_XRAY_USE_LOCAL_SPAN_FOR_MISSING_REMOTES"))) {
-          writer.name("name").value(span.localServiceName());
+          writer.name("name").value(span.localServiceName() == null ? "unknown" : span.localServiceName());
         } else {
           writer.name("name").value("unknown");
         }

--- a/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/UDPMessageEncoderTest.java
+++ b/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/UDPMessageEncoderTest.java
@@ -60,6 +60,26 @@ public class UDPMessageEncoderTest {
     assertThat(readString(json, "namespace")).isEqualTo("remote");
   }
 
+  @Test public void writeJson_custom_nameIsUnknown() throws Exception {
+    Span span = serverSpan.toBuilder()
+        .kind(null)
+        .name(null)
+        .build();
+
+    String json = writeJson(span);
+    assertThat(readString(json, "name")).isEqualTo("unknown");
+  }
+
+  @Test public void writeJson_custom_nameIsName() throws Exception {
+    Span span = serverSpan.toBuilder()
+        .kind(null)
+        .name("hystrix")
+        .build();
+
+    String json = writeJson(span, true);
+    assertThat(readString(json, "name")).isEqualTo("hystrix");
+  }
+
   @Test public void writeJson_client_nameIsUnknown() throws Exception {
     Span span = serverSpan.toBuilder()
         .kind(Span.Kind.CLIENT)

--- a/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/UDPMessageEncoderTest.java
+++ b/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/UDPMessageEncoderTest.java
@@ -85,6 +85,17 @@ public class UDPMessageEncoderTest {
     assertThat(readString(json, "name")).isEqualTo("master");
   }
 
+  @Test public void writeJson_client_nameIsUnknownWhenLocalServiceNameNull() throws Exception {
+    environmentVariables.set("AWS_XRAY_USE_LOCAL_SPAN_FOR_MISSING_REMOTES", "true");
+
+    Span span = serverSpan.toBuilder()
+        .kind(Span.Kind.CLIENT)
+        .build();
+
+    String json = writeJson(span);
+    assertThat(readString(json, "name")).isEqualTo("unknown");
+  }
+
   @Test public void writeJson_client_remoteEndpointIsName() throws Exception {
     Span span = serverSpan.toBuilder()
         .kind(Span.Kind.CLIENT)


### PR DESCRIPTION
With reference to https://github.com/openzipkin/zipkin-aws/issues/87 this PR adds the possibility to use local service names as segmente name for span of type different than SERVER and CONSUMER.
By default "unknown" is still sent if the remote service name is null, only if the AWS_XRAY_USE_LOCAL_SPAN_FOR_MISSING_REMOTES environment variable is set to `true` the local service name is used.

As an example (using spring-boot 2 based Java applications) by default these spans:
```
[{
  "traceId": "5b07b67fed3a0b4570cbdfe07b779e32",
  "parentId": "f3d698d7b353651f",
  "id": "164d63874559fbdf",
  "kind": "CLIENT",
  "name": "get",
  "timestamp": 1527232127973431,
  "duration": 22109,
  "localEndpoint": {
    "serviceName": "security-gateway-aws",
    "ipv4": "192.168.0.171"
  },
  "tags": {
    "http.method": "GET",
    "http.path": "/test-app/v1/public"
  }
}, {
  "traceId": "5b07b67fed3a0b4570cbdfe07b779e32",
  "parentId": "02e913691d305aa0",
  "id": "f3d698d7b353651f",
  "name": "hystrix",
  "timestamp": 1527232127972476,
  "duration": 23595,
  "localEndpoint": {
    "serviceName": "security-gateway-aws",
    "ipv4": "192.168.0.171"
  }
}, {
  "traceId": "5b07b67fed3a0b4570cbdfe07b779e32",
  "parentId": "70cbdfe07b779e32",
  "id": "02e913691d305aa0",
  "kind": "CLIENT",
  "name": "get",
  "timestamp": 1527232127972240,
  "duration": 23838,
  "localEndpoint": {
    "serviceName": "security-gateway-aws",
    "ipv4": "192.168.0.171"
  },
  "tags": {
    "http.method": "GET",
    "http.path": "/test-app/v1/public"
  }
}, {
  "traceId": "5b07b67fed3a0b4570cbdfe07b779e32",
  "id": "70cbdfe07b779e32",
  "kind": "SERVER",
  "name": "get",
  "timestamp": 1527232127970111,
  "duration": 29131,
  "localEndpoint": {
    "serviceName": "security-gateway-aws",
    "ipv4": "192.168.0.171"
  },
  "remoteEndpoint": {
    "ipv4": "127.0.0.1",
    "port": 33060
  },
  "tags": {
    "http.method": "GET",
    "http.path": "/test-app/v1/public"
  }
}]
```
result in these X-Ray segments:
```
{
  "trace_id": "1-5b07b67f-ed3a0b4570cbdfe07b779e32",
  "parent_id": "f3d698d7b353651f",
  "id": "164d63874559fbdf",
  "type": "subsegment",
  "namespace": "remote",
  "name": "unknown",
  "start_time": 1.527232127973431E9,
  "end_time": 1.52723212799554E9,
  "http": {
    "request": {
      "method": "GET"
    }
  },
  "annotations": {
    "operation": "get",
    "http_path": "/test-app/v1/public"
  }
}

{
  "trace_id": "1-5b07b67f-ed3a0b4570cbdfe07b779e32",
  "parent_id": "02e913691d305aa0",
  "id": "f3d698d7b353651f",
  "type": "subsegment",
  "name": "unknown",
  "start_time": 1.527232127972476E9,
  "end_time": 1.527232127996071E9
}

{
  "trace_id": "1-5b07b67f-ed3a0b4570cbdfe07b779e32",
  "parent_id": "70cbdfe07b779e32",
  "id": "02e913691d305aa0",
  "type": "subsegment",
  "namespace": "remote",
  "name": "unknown",
  "start_time": 1.52723212797224E9,
  "end_time": 1.527232127996078E9,
  "http": {
    "request": {
      "method": "GET"
    }
  },
  "annotations": {
    "operation": "get",
    "http_path": "/test-app/v1/public"
  }
}

{
  "trace_id": "1-5b07b67f-ed3a0b4570cbdfe07b779e32",
  "id": "70cbdfe07b779e32",
  "name": "security-gateway-aws",
  "start_time": 1.527232127970111E9,
  "end_time": 1.527232127999242E9,
  "http": {
    "request": {
      "method": "GET"
    }
  },
  "annotations": {
    "operation": "get",
    "http_path": "/test-app/v1/public"
  }
}
```

while with the environment variable set these spans:
```
[{
  "traceId": "5b07c4dd8167bc728c9369499184df04",
  "parentId": "2561d4b051f72922",
  "id": "0d32b6ca15c75375",
  "kind": "CLIENT",
  "name": "get",
  "timestamp": 1527235805895055,
  "duration": 6568,
  "localEndpoint": {
    "serviceName": "security-gateway-aws",
    "ipv4": "192.168.0.171"
  },
  "tags": {
    "http.method": "GET",
    "http.path": "/test-app/v1/public"
  }
}, {
  "traceId": "5b07c4dd8167bc728c9369499184df04",
  "parentId": "8c9369499184df04",
  "id": "7b25c19865b5ee2c",
  "kind": "CLIENT",
  "name": "get",
  "timestamp": 1527235805888945,
  "duration": 19229,
  "localEndpoint": {
    "serviceName": "security-gateway-aws",
    "ipv4": "192.168.0.171"
  },
  "tags": {
    "http.method": "GET",
    "http.path": "/test-app/v1/public"
  }
}, {
  "traceId": "5b07c4dd8167bc728c9369499184df04",
  "parentId": "7b25c19865b5ee2c",
  "id": "2561d4b051f72922",
  "name": "hystrix",
  "timestamp": 1527235805890880,
  "duration": 21261,
  "localEndpoint": {
    "serviceName": "security-gateway-aws",
    "ipv4": "192.168.0.171"
  }
}, {
  "traceId": "5b07c4dd8167bc728c9369499184df04",
  "id": "8c9369499184df04",
  "kind": "SERVER",
  "name": "get",
  "timestamp": 1527235805883133,
  "duration": 29543,
  "localEndpoint": {
    "serviceName": "security-gateway-aws",
    "ipv4": "192.168.0.171"
  },
  "remoteEndpoint": {
    "ipv4": "127.0.0.1",
    "port": 42386
  },
  "tags": {
    "http.method": "GET",
    "http.path": "/test-app/v1/public"
  }
}]
```
result in these X-Ray segments:
```
{
  "trace_id": "1-5b07c4dd-8167bc728c9369499184df04",
  "parent_id": "2561d4b051f72922",
  "id": "0d32b6ca15c75375",
  "type": "subsegment",
  "namespace": "remote",
  "name": "security-gateway-aws",
  "start_time": 1.527235805895055E9,
  "end_time": 1.527235805901623E9,
  "http": {
    "request": {
      "method": "GET"
    }
  },
  "annotations": {
    "operation": "get",
    "http_path": "/test-app/v1/public"
  }
}

{
  "trace_id": "1-5b07c4dd-8167bc728c9369499184df04",
  "parent_id": "8c9369499184df04",
  "id": "7b25c19865b5ee2c",
  "type": "subsegment",
  "namespace": "remote",
  "name": "security-gateway-aws",
  "start_time": 1.527235805888945E9,
  "end_time": 1.527235805908174E9,
  "http": {
    "request": {
      "method": "GET"
    }
  },
  "annotations": {
    "operation": "get",
    "http_path": "/test-app/v1/public"
  }
}

{
  "trace_id": "1-5b07c4dd-8167bc728c9369499184df04",
  "parent_id": "7b25c19865b5ee2c",
  "id": "2561d4b051f72922",
  "type": "subsegment",
  "name": "security-gateway-aws",
  "start_time": 1.52723580589088E9,
  "end_time": 1.527235805912141E9
}

{
  "trace_id": "1-5b07c4dd-8167bc728c9369499184df04",
  "id": "8c9369499184df04",
  "name": "security-gateway-aws",
  "start_time": 1.527235805883133E9,
  "end_time": 1.527235805912676E9,
  "http": {
    "request": {
      "method": "GET"
    }
  },
  "annotations": {
    "operation": "get",
    "http_path": "/test-app/v1/public"
  }
}
```