### PR TITLE
Fix (?) releasing via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,6 @@ workflows:
             tags:
               only: /\d+\.\d+\.\d+/
       - trigger_publish:
-          requires:
-            - build
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,10 @@ workflows:
   version: 2
   build_and_publish:
     jobs:
-      - build
+      - build:
+          filters:
+           tags:
+              only: /\d+\.\d+\.\d+/
       - publish_snapshot:
           requires:
             - build


### PR DESCRIPTION
**Problem**: as noted in https://github.com/openzipkin/zipkin-aws/pull/95#issuecomment-408819158, the release process (initiated by pushing a tag `release-MAJOR.MINOR.PATCH`) wasn't triggered. CircleCI at https://circleci.com/gh/openzipkin/workflows/zipkin-aws/tree/release-0.12.1 says “zipkin-aws/release-0.12.1 has no workflows configured”.

**Analysis**: the documentation states that unless explicitly configured, workflow jobs are not triggered for any tags. `trigger_publish` is configured to be triggered on `release-` tags. However, it `requires` `build`, and `build` is _not_ configured with a `tags` filter, so it was _not_ run. Note also that `build` is not an actual dependency of `trigger_publish` (but it _is_ an actual dependency of `publish_stable`).

**Solution**: remove the dependency of `trigger_publish` on `build`, and allow `build` to run on tags `MAJOR.MINOR.PATCH`, which is the same filter configured for `publish_stable`. The build flow should now go:

 * commit on `master`: `build` -> `publish_snapshot`
 * tag `release-0.0.0` -> `trigger_publish` creates tag `0.0.0` -> `build` -> `publish_stable` (I expect `publish_snapshot` to not run because it has no `tags` filter, and the default is to not trigger on tags).

**PoC**: pushed a tag `release-0.0.0` to `abesto/zipkin-aws` with these changes, and it triggered a workflow (which terminated early at the “don't run on forks” check we have in `.circleci/config.yml` for the `trigger_publish` step): https://circleci.com/gh/abesto/zipkin-aws/2