### PR TITLE
Removes extra space in the config, corrects doc

### DIFF
--- a/autoconfigure/collector-kinesis/src/main/resources/zipkin-server-kinesis.yml
+++ b/autoconfigure/collector-kinesis/src/main/resources/zipkin-server-kinesis.yml
@@ -16,6 +16,6 @@ zipkin:
       # Optional AWS STS region endpoint to use, defaults to KINESIS_AWS_REGION
       aws-sts-region: ${KINESIS_AWS_STS_REGION:${zipkin.collector.kinesis.aws-kinesis-region}}
       # Optional AWS Kinesis Region, defaults to AWS_REGION
-      aws-kinesis-region: ${KINESIS_AWS_REGION: ${zipkin.collector.kinesis.aws-region}}
+      aws-kinesis-region: ${KINESIS_AWS_REGION:${zipkin.collector.kinesis.aws-region}}
       # Optional AWS Region, implicitly sets STS and Kinesis regions if not provided, defaults to us-east-1
       aws-region: ${AWS_REGION:us-east-1}

--- a/sender-kinesis/README.md
+++ b/sender-kinesis/README.md
@@ -36,7 +36,7 @@ The credentials that your service has requires the following permissions in orde
 The message's binary data includes a list of spans. Supported encodings
 are the same as the http [POST /spans](http://zipkin.io/zipkin-api/#/paths/%252Fspans) body.
 
-Encoding defaults to thrift, but can be overridden to use json instead.
+Encoding defaults to json, but can be overridden to PROTO3 if required.
 
 Note: Span encoding happens before Kinesis Base64 data encoding.
 For example, if you look at a raw `PutRecord` request, the `Data` field

--- a/sender-sqs/README.md
+++ b/sender-sqs/README.md
@@ -36,7 +36,7 @@ The credentials that your service has requires the following permissions in orde
 The message's binary data includes a list of spans. Supported encodings
 are the same as the http [POST /spans](http://zipkin.io/zipkin-api/#/paths/%252Fspans) body.
 
-Encoding defaults to thrift, but can be overridden to use json instead.
+Encoding defaults to json, but can be overridden to use PROTO3 instead.
 
 Unless the message is ascii, it is Base64 encoded before being sent. For
 example, plain json is sent as is. Thrift or json messages that include


### PR DESCRIPTION
Extra space in the config breaks the yaml file and the kinesis collector doesn't start. 