### PR TITLE
Uses latest layout factory and fixes a little drift

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip

--- a/autoconfigure/collector-kinesis/README.md
+++ b/autoconfigure/collector-kinesis/README.md
@@ -80,7 +80,7 @@ The following IAM permissions are required by the KinesisCollector
 
 Once your collector is enabled, verify it is running:
 ```bash
-$ curl -s localhost:9411/health|jq .zipkin.KinesisCollector
+$ curl -s localhost:9411/health|jq .zipkin.details.KinesisCollector
 {
   "status": "UP"
 }

--- a/autoconfigure/collector-sqs/README.md
+++ b/autoconfigure/collector-sqs/README.md
@@ -74,7 +74,7 @@ The following IAM permissions are required by the SQSCollector
 
 Once your collector is enabled, verify it is running:
 ```bash
-curl -s localhost:9411/health|jq .zipkin.SQSCollector
+curl -s localhost:9411/health|jq .zipkin.details.SQSCollector
 {
   "status": "UP"
 }

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -72,7 +72,7 @@
         <configuration>
           <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
           <excludeGroupIds>
-            io.zipkin.zipkin2,io.zipkin.reporter2,org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,com.google.guava
+            io.zipkin.zipkin2,io.zipkin.reporter2,org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,com.google.guava,com.squareup.moshi,com.squareup.okio,com.squareup.okhttp
           </excludeGroupIds>
         </configuration>
       </plugin>

--- a/autoconfigure/storage-elasticsearch-aws/src/main/resources/zipkin-server-elasticsearch-aws.yml
+++ b/autoconfigure/storage-elasticsearch-aws/src/main/resources/zipkin-server-elasticsearch-aws.yml
@@ -1,4 +1,8 @@
 # When enabled, this allows shorter env properties (ex -Dspring.profiles.active=elasticsearch-aws)
+spring:
+  main:
+    # ZipkinElasticsearchAwsStorageAutoConfiguration overrides the bean named 'storage'
+    allow-bean-definition-overriding: true
 zipkin:
   storage:
     elasticsearch:

--- a/autoconfigure/storage-xray/README.md
+++ b/autoconfigure/storage-xray/README.md
@@ -59,7 +59,7 @@ for users that prefer a file based approach.
 
 Once your storage is enabled, verify it is running:
 ```bash
-$ curl -s localhost:9411/health|jq .zipkin.XrayStorage
+$ curl -s localhost:9411/health|jq .zipkin.details.XRayUDPStorage
 {
   "status": "UP"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <errorprone.args />
     <errorprone.version>2.3.2</errorprone.version>
 
-    <maven-failsafe-plugin.version>2.22.1</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.0.0-M1</maven-failsafe-plugin.version>
   </properties>
 
   <name>Zipkin AWS (Parent)</name>
@@ -166,12 +166,12 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
-        <version>3.11.0</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
-        <version>3.11.0</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
@@ -212,7 +212,7 @@
   <build>
     <pluginManagement>
       <plugins>
-        <!-- mvn -N io.takari:maven:wrapper -Dmaven=3.5.4 -->
+        <!-- mvn -N io.takari:maven:wrapper -Dmaven=3.6.0 -->
         <plugin>
           <groupId>io.takari</groupId>
           <artifactId>maven</artifactId>
@@ -252,7 +252,7 @@
             <dependency>
               <groupId>io.zipkin.layout</groupId>
               <artifactId>zipkin-layout-factory</artifactId>
-              <version>0.0.3</version>
+              <version>0.0.4</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -263,7 +263,7 @@
       <plugin>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>retrolambda-maven-plugin</artifactId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
         <executions>
           <execution>
             <goals>
@@ -316,18 +316,15 @@
         </executions>
       </plugin>
 
-      <!-- Ensures checksums are added to published jars -->
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
-        <configuration>
-          <createChecksum>true</createChecksum>
-        </configuration>
+        <version>3.0.0-M1</version>
       </plugin>
 
+      <!-- Uploads occur as a last step (which also adds checksums) -->
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
+        <version>3.0.0-M1</version>
       </plugin>
 
       <plugin>

--- a/storage-xray-udp/pom.xml
+++ b/storage-xray-udp/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
Recently, bean overriding is disabled by default. This affected aws
elasticsearch.