### PR TITLE
Updates to latest brave and avoids internal type

### DIFF
--- a/brave-propagation-aws/src/main/java/brave/propagation/aws/AWSPropagation.java
+++ b/brave-propagation-aws/src/main/java/brave/propagation/aws/AWSPropagation.java
@@ -24,8 +24,8 @@ import brave.propagation.TraceIdContext;
 import java.util.Collections;
 import java.util.List;
 
-import static brave.internal.HexCodec.writeHexByte;
-import static brave.internal.HexCodec.writeHexLong;
+import static brave.propagation.aws.HexCodec.writeHexByte;
+import static brave.propagation.aws.HexCodec.writeHexLong;
 
 /**
  * Utility for working with Amazon Web Services Trace IDs, for example reading from headers or

--- a/brave-propagation-aws/src/main/java/brave/propagation/aws/HexCodec.java
+++ b/brave-propagation-aws/src/main/java/brave/propagation/aws/HexCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.propagation.aws;
+
+// code originally imported from brave.internal.HexCodec
+final class HexCodec {
+
+  /** Inspired by {@code okio.Buffer.writeLong} */
+  static void writeHexLong(char[] data, int pos, long v) {
+    writeHexByte(data, pos + 0, (byte) ((v >>> 56L) & 0xff));
+    writeHexByte(data, pos + 2, (byte) ((v >>> 48L) & 0xff));
+    writeHexByte(data, pos + 4, (byte) ((v >>> 40L) & 0xff));
+    writeHexByte(data, pos + 6, (byte) ((v >>> 32L) & 0xff));
+    writeHexByte(data, pos + 8, (byte) ((v >>> 24L) & 0xff));
+    writeHexByte(data, pos + 10, (byte) ((v >>> 16L) & 0xff));
+    writeHexByte(data, pos + 12, (byte) ((v >>> 8L) & 0xff));
+    writeHexByte(data, pos + 14, (byte) (v & 0xff));
+  }
+
+  static final char[] HEX_DIGITS =
+      {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+  static void writeHexByte(char[] data, int pos, byte b) {
+    data[pos + 0] = HEX_DIGITS[(b >> 4) & 0xf];
+    data[pos + 1] = HEX_DIGITS[b & 0xf];
+  }
+
+  HexCodec() {
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
 
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
 
-    <zipkin.version>2.11.11</zipkin.version>
+    <zipkin.version>2.11.12</zipkin.version>
     <zipkin-reporter2.version>2.7.13</zipkin-reporter2.version>
-    <brave.version>5.5.2</brave.version>
+    <brave.version>5.6.0</brave.version>
 
     <slf4j.version>1.7.25</slf4j.version>
     <log4j.version>2.11.1</log4j.version>


### PR DESCRIPTION
We accidentally dependended on an internal type without shading it. This
moves the two methods needed here.

Fixes #118