### PR TITLE
SQS Message Propagation Injection

### DIFF
--- a/brave-instrumentation/aws-java-sdk-sqs/README.md
+++ b/brave-instrumentation/aws-java-sdk-sqs/README.md
@@ -1,0 +1,23 @@
+# AWS SQS Messaging Instrumentation
+
+This module contains instrumentation for AWS `AmazonSQS` client `SendMessage*` request types.
+
+The `SqsMessageTracing` type provides a `RequestHandler2` instance that can be added to your clients
+at build time. It adds tracing headers to both `SendMessageRequest` and `SendMessageBatchRequest`
+types. In the case of `SendMessageBatchRequest` each message in the batch gets it's own `Span` and
+headers added.
+
+## Usage
+
+You will want to create your SQS client and add the request handler
+
+```java
+Tracing tracing = ...;
+SqsMessageTracing sqsMessageTracing = SqsMessageTracing.create(tracing);
+
+AmazonSQSAsync client = AmazonSQSAsyncClientBuilder.standard()
+    .withRequestHandlers(sqsMessageTracing.requestHandler())
+    .build();
+```
+
+Now use your SQS client as you normally would and spans will be attached to outgoing messages.

--- a/brave-instrumentation/aws-java-sdk-sqs/pom.xml
+++ b/brave-instrumentation/aws-java-sdk-sqs/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>brave-instrumentation-parent</artifactId>
+        <groupId>io.zipkin.aws</groupId>
+        <version>0.15.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>brave-instrumentation-aws-java-sdk-sqs</artifactId>
+
+    <properties>
+        <main.basedir>${project.basedir}/../..</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-context-log4j2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/brave-instrumentation/aws-java-sdk-sqs/pom.xml
+++ b/brave-instrumentation/aws-java-sdk-sqs/pom.xml
@@ -1,41 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <artifactId>brave-instrumentation-parent</artifactId>
-        <groupId>io.zipkin.aws</groupId>
-        <version>0.15.4-SNAPSHOT</version>
-    </parent>
+  <parent>
+    <artifactId>brave-instrumentation-parent</artifactId>
+    <groupId>io.zipkin.aws</groupId>
+    <version>0.15.4-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>brave-instrumentation-aws-java-sdk-sqs</artifactId>
+  <artifactId>brave-instrumentation-aws-java-sdk-sqs</artifactId>
 
-    <properties>
-        <main.basedir>${project.basedir}/../..</main.basedir>
-    </properties>
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>io.zipkin.brave</groupId>
-            <artifactId>brave</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sqs</artifactId>
+    </dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.zipkin.brave</groupId>
-            <artifactId>brave-context-log4j2</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-context-log4j2</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/brave-instrumentation/aws-java-sdk-sqs/pom.xml
+++ b/brave-instrumentation/aws-java-sdk-sqs/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>brave-instrumentation-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.15.4-SNAPSHOT</version>
+    <version>0.15.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>brave-instrumentation-aws-java-sdk-sqs</artifactId>

--- a/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java
@@ -85,7 +85,7 @@ final class SendMessageTracingRequestHandler extends RequestHandler2 {
       span = tracer.newChild(maybeParent);
     }
 
-    span.name("publish-batch").start();
+    span.name("publish-batch").remoteServiceName("amazon-sqs").start();
     try (Tracer.SpanInScope scope = tracer.withSpanInScope(span)) {
       for (SendMessageBatchRequestEntry entry : request.getEntries()) {
         injectPerMessage(request.getQueueUrl(), entry.getMessageAttributes());
@@ -109,7 +109,8 @@ final class SendMessageTracingRequestHandler extends RequestHandler2 {
 
     if (!span.isNoop()) {
       span.kind(Span.Kind.PRODUCER).name("publish");
-      span.remoteServiceName("amazon-sqs/" + queueUrl);
+      span.remoteServiceName("amazon-sqs");
+      span.tag("queue.url", queueUrl);
       // incur timestamp overhead only once
       long timestamp = tracing.clock(span.context()).currentTimeMicroseconds();
       span.start(timestamp).finish(timestamp);

--- a/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package brave.instrumentation.aws.sqs;
 
 import brave.Span;
@@ -13,103 +26,106 @@ import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
-
 import java.util.Map;
 
 final class SendMessageTracingRequestHandler extends RequestHandler2 {
 
-    static final Propagation.Setter<Map<String, MessageAttributeValue>, String> SETTER =
-            new Propagation.Setter<Map<String, MessageAttributeValue>, String>() {
-        @Override public void put(Map<String, MessageAttributeValue> carrier, String key, String value) {
-            carrier.put(key, new MessageAttributeValue().withDataType("String").withStringValue(value));
+  static final Propagation.Setter<Map<String, MessageAttributeValue>, String> SETTER =
+      new Propagation.Setter<Map<String, MessageAttributeValue>, String>() {
+        @Override
+        public void put(Map<String, MessageAttributeValue> carrier, String key, String value) {
+          carrier.put(key,
+              new MessageAttributeValue().withDataType("String").withStringValue(value));
         }
-    };
+      };
 
-    static final Propagation.Getter<Map<String,MessageAttributeValue>, String> GETTER =
-            new Propagation.Getter<Map<String, MessageAttributeValue>, String>() {
+  static final Propagation.Getter<Map<String, MessageAttributeValue>, String> GETTER =
+      new Propagation.Getter<Map<String, MessageAttributeValue>, String>() {
         @Override public String get(Map<String, MessageAttributeValue> carrier, String key) {
-            return carrier.containsKey(key) ? carrier.get(key).getStringValue() : null;
+          return carrier.containsKey(key) ? carrier.get(key).getStringValue() : null;
         }
-    };
+      };
 
-    final Tracing tracing;
-    final Tracer tracer;
-    final CurrentTraceContext currentTraceContext;
-    final TraceContext.Injector<Map<String, MessageAttributeValue>> injector;
-    final TraceContext.Extractor<Map<String, MessageAttributeValue>> extractor;
+  final Tracing tracing;
+  final Tracer tracer;
+  final CurrentTraceContext currentTraceContext;
+  final TraceContext.Injector<Map<String, MessageAttributeValue>> injector;
+  final TraceContext.Extractor<Map<String, MessageAttributeValue>> extractor;
 
-    SendMessageTracingRequestHandler(Tracing tracing) {
-        this.tracing = tracing;
-        this.tracer = tracing.tracer();
-        this.currentTraceContext = tracing.currentTraceContext();
-        this.injector = tracing.propagation().injector(SETTER);
-        this.extractor = tracing.propagation().extractor(GETTER);
+  SendMessageTracingRequestHandler(Tracing tracing) {
+    this.tracing = tracing;
+    this.tracer = tracing.tracer();
+    this.currentTraceContext = tracing.currentTraceContext();
+    this.injector = tracing.propagation().injector(SETTER);
+    this.extractor = tracing.propagation().extractor(GETTER);
+  }
+
+  @Override
+  public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request) {
+    if (request instanceof SendMessageRequest) {
+      handleSendMessageRequest((SendMessageRequest) request);
+    } else if (request instanceof SendMessageBatchRequest) {
+      handleSendMessageBatchRequest((SendMessageBatchRequest) request);
+    }
+    return request;
+  }
+
+  private void handleSendMessageRequest(SendMessageRequest request) {
+    injectPerMessage(request.getQueueUrl(), request.getMessageAttributes());
+  }
+
+  private void handleSendMessageBatchRequest(SendMessageBatchRequest request) {
+    TraceContext maybeParent = currentTraceContext.get();
+
+    Span span;
+    if (maybeParent == null) {
+      span = tracer.nextSpan();
+    } else {
+      // If we have a span in scope assume headers were cleared before
+      span = tracer.newChild(maybeParent);
     }
 
-    @Override
-    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request) {
-        if (request instanceof SendMessageRequest) {
-            handleSendMessageRequest((SendMessageRequest) request);
-        } else if (request instanceof SendMessageBatchRequest) {
-            handleSendMessageBatchRequest((SendMessageBatchRequest) request);
-        }
-        return request;
+    span.name("publish-batch").start();
+    try (Tracer.SpanInScope scope = tracer.withSpanInScope(span)) {
+      for (SendMessageBatchRequestEntry entry : request.getEntries()) {
+        injectPerMessage(request.getQueueUrl(), entry.getMessageAttributes());
+      }
+    } finally {
+      span.finish();
+    }
+  }
+
+  private void injectPerMessage(String queueUrl,
+      Map<String, MessageAttributeValue> messageAttributes) {
+    TraceContext maybeParent = currentTraceContext.get();
+
+    Span span;
+    if (maybeParent == null) {
+      span = tracer.nextSpan(extractAndClearHeaders(messageAttributes));
+    } else {
+      // If we have a span in scope assume headers were cleared before
+      span = tracer.newChild(maybeParent);
     }
 
-    private void handleSendMessageRequest(SendMessageRequest request) {
-        injectPerMessage(request.getQueueUrl(), request.getMessageAttributes());
+    if (!span.isNoop()) {
+      span.kind(Span.Kind.PRODUCER).name("publish");
+      span.remoteServiceName("amazon-sqs/" + queueUrl);
+      // incur timestamp overhead only once
+      long timestamp = tracing.clock(span.context()).currentTimeMicroseconds();
+      span.start(timestamp).finish(timestamp);
     }
 
-    private void handleSendMessageBatchRequest(SendMessageBatchRequest request) {
-        TraceContext maybeParent = currentTraceContext.get();
+    injector.inject(span.context(), messageAttributes);
+  }
 
-        Span span;
-        if (maybeParent == null) {
-            span = tracer.nextSpan();
-        } else {
-            // If we have a span in scope assume headers were cleared before
-            span = tracer.newChild(maybeParent);
-        }
+  private TraceContextOrSamplingFlags extractAndClearHeaders(
+      Map<String, MessageAttributeValue> messageAttributes) {
+    TraceContextOrSamplingFlags extracted = extractor.extract(messageAttributes);
 
-        span.name("publish-batch").start();
-        try (Tracer.SpanInScope scope = tracer.withSpanInScope(span)) {
-            for (SendMessageBatchRequestEntry entry : request.getEntries()) {
-                injectPerMessage(request.getQueueUrl(), entry.getMessageAttributes());
-            }
-        } finally {
-            span.finish();
-        }
+    for (String propagationKey : tracing.propagation().keys()) {
+      messageAttributes.remove(propagationKey);
     }
 
-    private void injectPerMessage(String queueUrl, Map<String, MessageAttributeValue> messageAttributes) {
-        TraceContext maybeParent = currentTraceContext.get();
-
-        Span span;
-        if (maybeParent == null) {
-            span = tracer.nextSpan(extractAndClearHeaders(messageAttributes));
-        } else {
-            // If we have a span in scope assume headers were cleared before
-            span = tracer.newChild(maybeParent);
-        }
-
-        if (!span.isNoop()) {
-            span.kind(Span.Kind.PRODUCER).name("publish");
-            span.remoteServiceName("amazon-sqs/" + queueUrl);
-            // incur timestamp overhead only once
-            long timestamp = tracing.clock(span.context()).currentTimeMicroseconds();
-            span.start(timestamp).finish(timestamp);
-        }
-
-        injector.inject(span.context(), messageAttributes);
-    }
-
-    private TraceContextOrSamplingFlags extractAndClearHeaders(Map<String, MessageAttributeValue> messageAttributes) {
-        TraceContextOrSamplingFlags extracted = extractor.extract(messageAttributes);
-
-        for (String propagationKey : tracing.propagation().keys()) {
-            messageAttributes.remove(propagationKey);
-        }
-
-        return extracted;
-    }
+    return extracted;
+  }
 }

--- a/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java
@@ -1,0 +1,115 @@
+package brave.instrumentation.aws.sqs;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+
+import java.util.Map;
+
+final class SendMessageTracingRequestHandler extends RequestHandler2 {
+
+    static final Propagation.Setter<Map<String, MessageAttributeValue>, String> SETTER =
+            new Propagation.Setter<Map<String, MessageAttributeValue>, String>() {
+        @Override public void put(Map<String, MessageAttributeValue> carrier, String key, String value) {
+            carrier.put(key, new MessageAttributeValue().withDataType("String").withStringValue(value));
+        }
+    };
+
+    static final Propagation.Getter<Map<String,MessageAttributeValue>, String> GETTER =
+            new Propagation.Getter<Map<String, MessageAttributeValue>, String>() {
+        @Override public String get(Map<String, MessageAttributeValue> carrier, String key) {
+            return carrier.containsKey(key) ? carrier.get(key).getStringValue() : null;
+        }
+    };
+
+    final Tracing tracing;
+    final Tracer tracer;
+    final CurrentTraceContext currentTraceContext;
+    final TraceContext.Injector<Map<String, MessageAttributeValue>> injector;
+    final TraceContext.Extractor<Map<String, MessageAttributeValue>> extractor;
+
+    SendMessageTracingRequestHandler(Tracing tracing) {
+        this.tracing = tracing;
+        this.tracer = tracing.tracer();
+        this.currentTraceContext = tracing.currentTraceContext();
+        this.injector = tracing.propagation().injector(SETTER);
+        this.extractor = tracing.propagation().extractor(GETTER);
+    }
+
+    @Override
+    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request) {
+        if (request instanceof SendMessageRequest) {
+            handleSendMessageRequest((SendMessageRequest) request);
+        } else if (request instanceof SendMessageBatchRequest) {
+            handleSendMessageBatchRequest((SendMessageBatchRequest) request);
+        }
+        return request;
+    }
+
+    private void handleSendMessageRequest(SendMessageRequest request) {
+        injectPerMessage(request.getQueueUrl(), request.getMessageAttributes());
+    }
+
+    private void handleSendMessageBatchRequest(SendMessageBatchRequest request) {
+        TraceContext maybeParent = currentTraceContext.get();
+
+        Span span;
+        if (maybeParent == null) {
+            span = tracer.nextSpan();
+        } else {
+            // If we have a span in scope assume headers were cleared before
+            span = tracer.newChild(maybeParent);
+        }
+
+        span.name("publish-batch").start();
+        try (Tracer.SpanInScope scope = tracer.withSpanInScope(span)) {
+            for (SendMessageBatchRequestEntry entry : request.getEntries()) {
+                injectPerMessage(request.getQueueUrl(), entry.getMessageAttributes());
+            }
+        } finally {
+            span.finish();
+        }
+    }
+
+    private void injectPerMessage(String queueUrl, Map<String, MessageAttributeValue> messageAttributes) {
+        TraceContext maybeParent = currentTraceContext.get();
+
+        Span span;
+        if (maybeParent == null) {
+            span = tracer.nextSpan(extractAndClearHeaders(messageAttributes));
+        } else {
+            // If we have a span in scope assume headers were cleared before
+            span = tracer.newChild(maybeParent);
+        }
+
+        if (!span.isNoop()) {
+            span.kind(Span.Kind.PRODUCER).name("publish");
+            span.remoteServiceName("amazon-sqs/" + queueUrl);
+            // incur timestamp overhead only once
+            long timestamp = tracing.clock(span.context()).currentTimeMicroseconds();
+            span.start(timestamp).finish(timestamp);
+        }
+
+        injector.inject(span.context(), messageAttributes);
+    }
+
+    private TraceContextOrSamplingFlags extractAndClearHeaders(Map<String, MessageAttributeValue> messageAttributes) {
+        TraceContextOrSamplingFlags extracted = extractor.extract(messageAttributes);
+
+        for (String propagationKey : tracing.propagation().keys()) {
+            messageAttributes.remove(propagationKey);
+        }
+
+        return extracted;
+    }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java
@@ -32,8 +32,7 @@ final class SendMessageTracingRequestHandler extends RequestHandler2 {
 
   static final Propagation.Setter<Map<String, MessageAttributeValue>, String> SETTER =
       new Propagation.Setter<Map<String, MessageAttributeValue>, String>() {
-        @Override
-        public void put(Map<String, MessageAttributeValue> carrier, String key, String value) {
+        @Override public void put(Map<String, MessageAttributeValue> carrier, String key, String value) {
           carrier.put(key,
               new MessageAttributeValue().withDataType("String").withStringValue(value));
         }

--- a/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SqsMessageTracing.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SqsMessageTracing.java
@@ -1,20 +1,33 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package brave.instrumentation.aws.sqs;
 
 import brave.Tracing;
 import com.amazonaws.handlers.RequestHandler2;
 
 public class SqsMessageTracing {
-    public static SqsMessageTracing create(Tracing tracing) {
-        return new SqsMessageTracing(tracing);
-    }
+  public static SqsMessageTracing create(Tracing tracing) {
+    return new SqsMessageTracing(tracing);
+  }
 
-    final RequestHandler2 requestHandler;
+  final RequestHandler2 requestHandler;
 
-    private SqsMessageTracing(Tracing tracing) {
-        this.requestHandler = new SendMessageTracingRequestHandler(tracing);
-    }
+  private SqsMessageTracing(Tracing tracing) {
+    this.requestHandler = new SendMessageTracingRequestHandler(tracing);
+  }
 
-    public RequestHandler2 getRequestHandler() {
-        return requestHandler;
-    }
+  public RequestHandler2 getRequestHandler() {
+    return requestHandler;
+  }
 }

--- a/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SqsMessageTracing.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SqsMessageTracing.java
@@ -1,0 +1,20 @@
+package brave.instrumentation.aws.sqs;
+
+import brave.Tracing;
+import com.amazonaws.handlers.RequestHandler2;
+
+public class SqsMessageTracing {
+    public static SqsMessageTracing create(Tracing tracing) {
+        return new SqsMessageTracing(tracing);
+    }
+
+    final RequestHandler2 requestHandler;
+
+    private SqsMessageTracing(Tracing tracing) {
+        this.requestHandler = new SendMessageTracingRequestHandler(tracing);
+    }
+
+    public RequestHandler2 getRequestHandler() {
+        return requestHandler;
+    }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SqsMessageTracing.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SqsMessageTracing.java
@@ -27,7 +27,7 @@ public class SqsMessageTracing {
     this.requestHandler = new SendMessageTracingRequestHandler(tracing);
   }
 
-  public RequestHandler2 getRequestHandler() {
+  public RequestHandler2 requestHandler() {
     return requestHandler;
   }
 }

--- a/brave-instrumentation/aws-java-sdk-sqs/src/test/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandlerTest.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/test/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandlerTest.java
@@ -126,7 +126,8 @@ public class SendMessageTracingRequestHandlerTest {
   private void verifyReportedPublishSpan(Span span) {
     assertThat(span.kind()).isEqualTo(Span.Kind.PRODUCER);
     assertThat(span.name()).isEqualTo("publish");
-    assertThat(span.remoteServiceName()).isEqualToIgnoringCase("amazon-sqs/queueUrl");
+    assertThat(span.remoteServiceName()).isEqualToIgnoringCase("amazon-sqs");
+    assertThat(span.tags().get("queue.url")).isEqualToIgnoringCase("queueUrl");
     assertThat(span.duration()).isEqualTo(1);
   }
 

--- a/brave-instrumentation/aws-java-sdk-sqs/src/test/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandlerTest.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/test/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandlerTest.java
@@ -1,0 +1,127 @@
+package brave.instrumentation.aws.sqs;
+
+import brave.Tracing;
+import brave.context.log4j2.ThreadContextScopeDecorator;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.sampler.Sampler;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Span;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SendMessageTracingRequestHandlerTest {
+    private BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
+
+    Tracing tracing;
+    TraceContext.Extractor<Map<String, MessageAttributeValue>> extractor;
+    SendMessageTracingRequestHandler handler;
+
+    @Before
+    public void setup() {
+        tracing = tracingBuilder().build();
+        extractor = tracing.propagation().extractor(SendMessageTracingRequestHandler.GETTER);
+
+        handler = new SendMessageTracingRequestHandler(tracing);
+    }
+
+    @After
+    public void cleanup() {
+        tracing.close();
+    }
+
+    @Test
+    public void handleSendMessageRequest() throws InterruptedException {
+        SendMessageRequest request = new SendMessageRequest("queueUrl", "test message content");
+
+        handler.beforeExecution(request);
+
+        // Verify propagation
+        verifyInjectedTraceContext(request.getMessageAttributes(), null);
+
+        // Verify Span
+        Span reportedSpan = spans.take();
+        verifyReportedPublishSpan(reportedSpan);
+
+        assertThat(spans.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void handleSendMessageBatchRequest() throws InterruptedException {
+        SendMessageBatchRequest request = new SendMessageBatchRequest("queueUrl");
+        SendMessageBatchRequestEntry entry1 = new SendMessageBatchRequestEntry("id1", "test message body 1");
+        SendMessageBatchRequestEntry entry2 = new SendMessageBatchRequestEntry("id2", "test message body 2");
+        request.withEntries(entry1, entry2);
+
+        handler.beforeExecution(request);
+
+        List<Span> reportedSpans = Arrays.asList(spans.take(), spans.take(), spans.take());
+
+        Span localParent = reportedSpans.stream().filter(s -> s.parentId() == null).findFirst().get();
+
+        // Verify propagation
+        for (SendMessageBatchRequestEntry entry : request.getEntries()) {
+            verifyInjectedTraceContext(entry.getMessageAttributes(), localParent);
+        }
+
+        // Verify Span
+        assertThat(localParent.name()).isEqualTo("publish-batch");
+
+        List<Span> messageSpans = reportedSpans.stream().filter(s -> s != localParent).collect(Collectors.toList());
+        for (Span span : messageSpans) {
+            verifyReportedPublishSpan(span);
+        }
+
+        assertThat(spans.size()).isEqualTo(0);
+    }
+
+    private void verifyInjectedTraceContext(Map<String, MessageAttributeValue> messageAttributes, Span parent) {
+        TraceContextOrSamplingFlags extracted = extractor.extract(messageAttributes);
+
+        assertThat(extracted.sampled()).isTrue();
+        assertThat(extracted.traceIdContext()).isNull();
+        assertThat(extracted.context()).isNotNull();
+
+        if (parent == null) {
+            assertThat(extracted.context().traceIdString()).isNotEmpty();
+            assertThat(extracted.context().parentId()).isNull();
+        } else {
+            assertThat(extracted.context().traceIdString()).isEqualTo(parent.traceId());
+            assertThat(extracted.context().parentIdString()).isEqualTo(parent.id());
+        }
+        assertThat(extracted.context().spanIdString()).isNotEmpty();
+    }
+
+    private void verifyReportedPublishSpan(Span span) {
+        assertThat(span.kind()).isEqualTo(Span.Kind.PRODUCER);
+        assertThat(span.name()).isEqualTo("publish");
+        assertThat(span.remoteServiceName()).isEqualToIgnoringCase("amazon-sqs/queueUrl");
+        assertThat(span.duration()).isEqualTo(1);
+    }
+
+    private Tracing.Builder tracingBuilder() {
+        return Tracing.newBuilder()
+                .spanReporter(spans::add)
+                .currentTraceContext(
+                        ThreadLocalCurrentTraceContext.newBuilder()
+                                .addScopeDecorator(ThreadContextScopeDecorator.create()) // connect to log4j
+                                .addScopeDecorator(StrictScopeDecorator.create())
+                                .build())
+                .sampler(Sampler.ALWAYS_SAMPLE);
+    }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs/src/test/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandlerTest.java
+++ b/brave-instrumentation/aws-java-sdk-sqs/src/test/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandlerTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package brave.instrumentation.aws.sqs;
 
 import brave.Tracing;
@@ -11,117 +24,120 @@ import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import zipkin2.Span;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SendMessageTracingRequestHandlerTest {
-    private BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
+  private BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 
-    Tracing tracing;
-    TraceContext.Extractor<Map<String, MessageAttributeValue>> extractor;
-    SendMessageTracingRequestHandler handler;
+  Tracing tracing;
+  TraceContext.Extractor<Map<String, MessageAttributeValue>> extractor;
+  SendMessageTracingRequestHandler handler;
 
-    @Before
-    public void setup() {
-        tracing = tracingBuilder().build();
-        extractor = tracing.propagation().extractor(SendMessageTracingRequestHandler.GETTER);
+  @Before
+  public void setup() {
+    tracing = tracingBuilder().build();
+    extractor = tracing.propagation().extractor(SendMessageTracingRequestHandler.GETTER);
 
-        handler = new SendMessageTracingRequestHandler(tracing);
+    handler = new SendMessageTracingRequestHandler(tracing);
+  }
+
+  @After
+  public void cleanup() {
+    tracing.close();
+  }
+
+  @Test
+  public void handleSendMessageRequest() throws InterruptedException {
+    SendMessageRequest request = new SendMessageRequest("queueUrl", "test message content");
+
+    handler.beforeExecution(request);
+
+    // Verify propagation
+    verifyInjectedTraceContext(request.getMessageAttributes(), null);
+
+    // Verify Span
+    Span reportedSpan = spans.take();
+    verifyReportedPublishSpan(reportedSpan);
+
+    assertThat(spans.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void handleSendMessageBatchRequest() throws InterruptedException {
+    SendMessageBatchRequest request = new SendMessageBatchRequest("queueUrl");
+    SendMessageBatchRequestEntry entry1 =
+        new SendMessageBatchRequestEntry("id1", "test message body 1");
+    SendMessageBatchRequestEntry entry2 =
+        new SendMessageBatchRequestEntry("id2", "test message body 2");
+    request.withEntries(entry1, entry2);
+
+    handler.beforeExecution(request);
+
+    List<Span> reportedSpans = Arrays.asList(spans.take(), spans.take(), spans.take());
+
+    Span localParent = reportedSpans.stream().filter(s -> s.parentId() == null).findFirst().get();
+
+    // Verify propagation
+    for (SendMessageBatchRequestEntry entry : request.getEntries()) {
+      verifyInjectedTraceContext(entry.getMessageAttributes(), localParent);
     }
 
-    @After
-    public void cleanup() {
-        tracing.close();
+    // Verify Span
+    assertThat(localParent.name()).isEqualTo("publish-batch");
+
+    List<Span> messageSpans =
+        reportedSpans.stream().filter(s -> s != localParent).collect(Collectors.toList());
+    for (Span span : messageSpans) {
+      verifyReportedPublishSpan(span);
     }
 
-    @Test
-    public void handleSendMessageRequest() throws InterruptedException {
-        SendMessageRequest request = new SendMessageRequest("queueUrl", "test message content");
+    assertThat(spans.size()).isEqualTo(0);
+  }
 
-        handler.beforeExecution(request);
+  private void verifyInjectedTraceContext(Map<String, MessageAttributeValue> messageAttributes,
+      Span parent) {
+    TraceContextOrSamplingFlags extracted = extractor.extract(messageAttributes);
 
-        // Verify propagation
-        verifyInjectedTraceContext(request.getMessageAttributes(), null);
+    assertThat(extracted.sampled()).isTrue();
+    assertThat(extracted.traceIdContext()).isNull();
+    assertThat(extracted.context()).isNotNull();
 
-        // Verify Span
-        Span reportedSpan = spans.take();
-        verifyReportedPublishSpan(reportedSpan);
-
-        assertThat(spans.size()).isEqualTo(0);
+    if (parent == null) {
+      assertThat(extracted.context().traceIdString()).isNotEmpty();
+      assertThat(extracted.context().parentId()).isNull();
+    } else {
+      assertThat(extracted.context().traceIdString()).isEqualTo(parent.traceId());
+      assertThat(extracted.context().parentIdString()).isEqualTo(parent.id());
     }
+    assertThat(extracted.context().spanIdString()).isNotEmpty();
+  }
 
-    @Test
-    public void handleSendMessageBatchRequest() throws InterruptedException {
-        SendMessageBatchRequest request = new SendMessageBatchRequest("queueUrl");
-        SendMessageBatchRequestEntry entry1 = new SendMessageBatchRequestEntry("id1", "test message body 1");
-        SendMessageBatchRequestEntry entry2 = new SendMessageBatchRequestEntry("id2", "test message body 2");
-        request.withEntries(entry1, entry2);
+  private void verifyReportedPublishSpan(Span span) {
+    assertThat(span.kind()).isEqualTo(Span.Kind.PRODUCER);
+    assertThat(span.name()).isEqualTo("publish");
+    assertThat(span.remoteServiceName()).isEqualToIgnoringCase("amazon-sqs/queueUrl");
+    assertThat(span.duration()).isEqualTo(1);
+  }
 
-        handler.beforeExecution(request);
-
-        List<Span> reportedSpans = Arrays.asList(spans.take(), spans.take(), spans.take());
-
-        Span localParent = reportedSpans.stream().filter(s -> s.parentId() == null).findFirst().get();
-
-        // Verify propagation
-        for (SendMessageBatchRequestEntry entry : request.getEntries()) {
-            verifyInjectedTraceContext(entry.getMessageAttributes(), localParent);
-        }
-
-        // Verify Span
-        assertThat(localParent.name()).isEqualTo("publish-batch");
-
-        List<Span> messageSpans = reportedSpans.stream().filter(s -> s != localParent).collect(Collectors.toList());
-        for (Span span : messageSpans) {
-            verifyReportedPublishSpan(span);
-        }
-
-        assertThat(spans.size()).isEqualTo(0);
-    }
-
-    private void verifyInjectedTraceContext(Map<String, MessageAttributeValue> messageAttributes, Span parent) {
-        TraceContextOrSamplingFlags extracted = extractor.extract(messageAttributes);
-
-        assertThat(extracted.sampled()).isTrue();
-        assertThat(extracted.traceIdContext()).isNull();
-        assertThat(extracted.context()).isNotNull();
-
-        if (parent == null) {
-            assertThat(extracted.context().traceIdString()).isNotEmpty();
-            assertThat(extracted.context().parentId()).isNull();
-        } else {
-            assertThat(extracted.context().traceIdString()).isEqualTo(parent.traceId());
-            assertThat(extracted.context().parentIdString()).isEqualTo(parent.id());
-        }
-        assertThat(extracted.context().spanIdString()).isNotEmpty();
-    }
-
-    private void verifyReportedPublishSpan(Span span) {
-        assertThat(span.kind()).isEqualTo(Span.Kind.PRODUCER);
-        assertThat(span.name()).isEqualTo("publish");
-        assertThat(span.remoteServiceName()).isEqualToIgnoringCase("amazon-sqs/queueUrl");
-        assertThat(span.duration()).isEqualTo(1);
-    }
-
-    private Tracing.Builder tracingBuilder() {
-        return Tracing.newBuilder()
-                .spanReporter(spans::add)
-                .currentTraceContext(
-                        ThreadLocalCurrentTraceContext.newBuilder()
-                                .addScopeDecorator(ThreadContextScopeDecorator.create()) // connect to log4j
-                                .addScopeDecorator(StrictScopeDecorator.create())
-                                .build())
-                .sampler(Sampler.ALWAYS_SAMPLE);
-    }
+  private Tracing.Builder tracingBuilder() {
+    return Tracing.newBuilder()
+        .spanReporter(spans::add)
+        .currentTraceContext(
+            ThreadLocalCurrentTraceContext.newBuilder()
+                .addScopeDecorator(ThreadContextScopeDecorator.create()) // connect to log4j
+                .addScopeDecorator(StrictScopeDecorator.create())
+                .build())
+        .sampler(Sampler.ALWAYS_SAMPLE);
+  }
 }

--- a/brave-instrumentation/pom.xml
+++ b/brave-instrumentation/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zipkin.aws</groupId>
@@ -32,7 +34,7 @@
   <modules>
     <module>aws-java-sdk-core</module>
     <module>aws-java-sdk-v2-core</module>
-      <module>aws-java-sdk-sqs</module>
+    <module>aws-java-sdk-sqs</module>
   </modules>
 
   <dependencyManagement>

--- a/brave-instrumentation/pom.xml
+++ b/brave-instrumentation/pom.xml
@@ -32,6 +32,7 @@
   <modules>
     <module>aws-java-sdk-core</module>
     <module>aws-java-sdk-v2-core</module>
+      <module>aws-java-sdk-sqs</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
This is an implementation of SQS message propagation injection using the `RequestHandler2` methods in order to avoid client wrapping. Still needs an integration test but I wanted to get eyes on it.

This is modeled after the Brave Rabbit instrumentation and the work in `smartthings-brave`