### PR TITLE
Implement support for aws ec2 segment in X-Ray UDP

### DIFF
--- a/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/UDPMessageEncoder.java
+++ b/storage-xray-udp/src/main/java/zipkin2/storage/xray_udp/UDPMessageEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -104,6 +104,9 @@ final class UDPMessageEncoder {
         awsRequestId = null,
         awsQueueUrl = null;
     String awsTableName = null;
+    // aws.ec2 section
+    String ec2AvailabilityZone = null,
+        ec2InstanceId = null;
     // cause section
     String causeWorkingDirectory = null, causeExceptions = null;
     boolean http = false, sql = false, aws = false, cause = false;
@@ -172,6 +175,12 @@ final class UDPMessageEncoder {
             continue;
           case "aws.table_name":
             awsTableName = entry.getValue();
+            continue;
+          case "aws.ec2.availability_zone":
+            ec2AvailabilityZone = entry.getValue();
+            continue;
+          case "aws.ec2.instance_id":
+            ec2InstanceId = entry.getValue();
             continue;
         }
       }
@@ -253,6 +262,13 @@ final class UDPMessageEncoder {
       if (awsRequestId != null) writer.name("request_id").value(awsRequestId);
       if (awsQueueUrl != null) writer.name("queue_url").value(awsQueueUrl);
       if (awsTableName != null) writer.name("table_name").value(awsTableName);
+      if (ec2AvailabilityZone != null || ec2InstanceId != null) {
+        writer.name("ec2");
+        writer.beginObject();
+        if (ec2AvailabilityZone != null) writer.name("availability_zone").value(ec2AvailabilityZone);
+        if (ec2InstanceId != null) writer.name("instance_id").value(ec2InstanceId);
+        writer.endObject();
+      }
       writer.endObject();
     }
 

--- a/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/UDPMessageEncoderTest.java
+++ b/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/UDPMessageEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -219,6 +219,22 @@ public class UDPMessageEncoderTest {
     String json = writeJson(span);
     assertThat(readMap(json, "aws"))
         .containsExactly(entry("region", "reg1"), entry("table_name", "table1"));
+  }
+
+  @Test
+  public void writeJson_aws_ec2() throws Exception {
+    Span span =
+            serverSpan
+                    .toBuilder()
+                    .putTag("aws.ec2.availability_zone", "us-west-2c")
+                    .putTag("aws.ec2.instance_id", "i-0b5a4678fc325bg98")
+                    .build();
+
+    String json = writeJson(span);
+    assertThat(readMap(json, "aws.ec2"))
+            .containsExactly(
+                    entry("availability_zone", "us-west-2c"),
+                    entry("instance_id", "i-0b5a4678fc325bg98"));
   }
 
   String writeJson(Span span) throws IOException {


### PR DESCRIPTION
This PR implements support for the [EC2 section](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-aws) of the AWS segment in the X-Ray span metadata.  

As a result, X-Ray is able to regognise the tag as a special tag instead of having it as an annotation. 
<img width="474" alt="Screen Shot 2019-04-14 at 2 33 25 pm" src="https://user-images.githubusercontent.com/1780970/56088382-02caf580-5ec3-11e9-814b-4a4ee0ef445b.png">
