### PR TITLE
Makes the health check less useless especially in docker

### DIFF
--- a/autoconfigure/storage-elasticsearch-aws/src/main/java/zipkin/autoconfigure/storage/elasticsearch/aws/ElasticsearchDomainEndpoint.java
+++ b/autoconfigure/storage-elasticsearch-aws/src/main/java/zipkin/autoconfigure/storage/elasticsearch/aws/ElasticsearchDomainEndpoint.java
@@ -64,9 +64,10 @@ final class ElasticsearchDomainEndpoint implements Supplier<EndpointGroup> {
       status = res.status();
       body = res.contentUtf8();
     } catch (RuntimeException | Error e) {
-      throw new RuntimeException("couldn't lookup AWS ES domain endpoint",
-          e instanceof CompletionException ? e.getCause() : e
-      );
+      String message = "couldn't lookup AWS ES domain endpoint";
+      Throwable cause = e instanceof CompletionException ? e.getCause() : e;
+      if (cause.getMessage() != null) message = message + ": " + cause.getMessage();
+      throw new RuntimeException(message, cause);
     }
 
     if (!status.codeClass().equals(HttpStatusClass.SUCCESS)) {


### PR DESCRIPTION
Health checks can only see the direct message of the throwable. When we
catch and re-wrap exceptions, we have to be careful not to throw away
the only thing that tells us what's wrong.

Ex before we hid the actual exception by guessing what the problem was.
Now, we can at least see what it is.
```bash
$ curl -s localhost:9411/health
{"status":"DOWN","zipkin":{"status":"DOWN","details":{"ElasticsearchStorage{initialEndpoints=aws://ap-southeast-1/zipkin-5, index=zipkin}":{"status":"DOWN","details":{"error":"java.lang.RuntimeException: couldn't lookup AWS ES domain endpoint: Unable to load AWS credentials from any provider in the chain: [EnvironmentVariableCredentialsProvider: Unable to load AWS credentials from environment variables (AWS_ACCESS_KEY_ID (or AWS_ACCESS_KEY) and AWS_SECRET_KEY (or AWS_SECRET_ACCESS_KEY)), SystemPropertiesCredentialsProvider: Unable to load AWS credentials from Java system properties (aws.accessKeyId and aws.secretKey), com.amazonaws.auth.profile.ProfileCredentialsProvider@6aa41445: profile file cannot be null, com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper@53ec57e2: Unable to load credentials from service endpoint]"}}}}}
```