### PR TITLE
Add release Dockerfile for zipkin-aws.

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,0 +1,47 @@
+#
+# Copyright 2016-2019 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+# Download artifact from bintray, where the artifact should have been published by now.
+
+FROM openzipkin/zipkin-builder as built
+
+ARG version
+
+# Download jars using Maven. It will try to resolve the artifact from Maven Central, which might
+# not work right away if the sync is taking time, followed by bintray, which should always work
+# since it's where we publish to.
+
+ARG MAVEN_GET="mvn org.apache.maven.plugins:maven-dependency-plugin:get -DremoteRepositories=bintray::::https://dl.bintray.com/openzipkin/maven -Dtransitive=false"
+
+RUN $MAVEN_GET -Dartifact=io.zipkin.aws:zipkin-module-collector-sqs:${version}:jar:module
+RUN $MAVEN_GET -Dartifact=io.zipkin.aws:zipkin-module-collector-kinesis:${version}:jar:module
+RUN $MAVEN_GET -Dartifact=io.zipkin.aws:zipkin-module-storage-elasticsearch-aws:${version}:jar:module
+RUN $MAVEN_GET -Dartifact=io.zipkin.aws:zipkin-module-storage-xray:${version}:jar:module
+
+WORKDIR /zipkin-aws
+
+ARG AWS_REPO=~/.m2/repository/io/zipkin/aws
+
+RUN mkdir sqs && cd sqs && cp ${AWS_REPO}/zipkin-module-collector-sqs/${version}/zipkin-module-collector-sqs-${version}-module.jar . && jar xf *.jar && rm *.jar
+RUN mkdir kinesis && cd kinesis && cp ${AWS_REPO}/zipkin-module-collector-kinesis/${version}/zipkin-module-collector-kinesis-${version}-module.jar . && jar xf *.jar && rm *.jar
+RUN mkdir elasticsearch-aws && cd elasticsearch-aws && cp ${AWS_REPO}/zipkin-module-storage-elasticsearch-aws/${version}/zipkin-module-elasticsearch-aws-${version}-module.jar . && jar xf *.jar && rm *.jar
+RUN mkdir xray && cd xray && cp ${AWS_REPO}/zipkin-module-storage-xray/${version}/zipkin-module-storage-xray-${version}-module.jar . && jar xf *.jar && rm *.jar
+
+FROM openzipkin/zipkin:2.18.0
+MAINTAINER Zipkin "https://zipkin.io/"
+
+COPY --from=0 /zipkin-aws/ /zipkin/lib/
+
+RUN echo > .xray_profile
+
+ENV MODULE_OPTS="-Dloader.path=lib/sqs,lib/kinesis,lib/elasticsearch-aws,lib/xray -Dspring.profiles.active=sqs,kinesis,elasticsearch-aws,xray"

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -v
+
+# This hook is called with the current directory set to the same as the Dockerfile, so we go back
+# to top level.
+cd ..
+
+# SOURCE_BRANCH contains the name of the branch or tag being built. Our build of the master branch
+# ignores this argument, while our build of release tags uses it to fetch the right release artifact.
+docker build --build-arg version="$SOURCE_BRANCH" -f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" .
+
+IFS=',' read -ra TAGS <<< "$DOCKER_TAG"
+for tag in ${TAGS[@]}; do
+  docker tag "$IMAGE_NAME" "${DOCKER_REPO}:${tag}"
+done


### PR DESCRIPTION
Not actually verified since it assumes the repo was migrated to the new module structure but here's the draft for now.