### PR TITLE
NPE fix for #147

### DIFF
--- a/brave-instrumentation/aws-java-sdk-core/pom.xml
+++ b/brave-instrumentation/aws-java-sdk-core/pom.xml
@@ -65,6 +65,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <version>1.19.0</version>

--- a/brave-instrumentation/aws-java-sdk-core/src/test/java/brave/instrumentation/aws/AwsClientTracingTest.java
+++ b/brave-instrumentation/aws-java-sdk-core/src/test/java/brave/instrumentation/aws/AwsClientTracingTest.java
@@ -27,6 +27,8 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import java.util.Collections;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -50,29 +52,12 @@ public class AwsClientTracingTest {
   public MockDynamoDBServer dynamoDBServer = new MockDynamoDBServer();
 
   @Rule
+  public MockS3Server s3Server = new MockS3Server();
+
+  @Rule
   public EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   private BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
-  private AmazonDynamoDB client;
-
-  @Before
-  public void setup() {
-    Tracing tracing = tracingBuilder().build();
-    HttpTracing httpTracing = HttpTracing.create(tracing);
-    AmazonDynamoDBClientBuilder clientBuilder = AmazonDynamoDBClientBuilder.standard()
-        .withCredentials(
-            new AWSStaticCredentialsProvider(new BasicAWSCredentials("access", "secret")))
-        .withEndpointConfiguration(
-            new AwsClientBuilder.EndpointConfiguration(dynamoDBServer.url(), "us-east-1"));
-
-    client = AwsClientTracing.create(httpTracing).build(clientBuilder);
-  }
-
-  @After
-  public void cleanup() {
-    Tracing.current().close();
-  }
-
   // See brave.http.ITHttp for rationale on polling after tests complete
   @Rule public TestRule assertSpansEmpty = new TestWatcher() {
     // only check success path to avoid masking assertion errors or exceptions
@@ -86,12 +71,39 @@ public class AwsClientTracingTest {
       }
     }
   };
+  private AmazonDynamoDB dbClient;
+  private AmazonS3 s3Client;
+
+  @Before
+  public void setup() {
+    Tracing tracing = tracingBuilder().build();
+    HttpTracing httpTracing = HttpTracing.create(tracing);
+    AmazonDynamoDBClientBuilder clientBuilder = AmazonDynamoDBClientBuilder.standard()
+        .withCredentials(
+            new AWSStaticCredentialsProvider(new BasicAWSCredentials("access", "secret")))
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(dynamoDBServer.url(), "us-east-1"));
+
+    dbClient = AwsClientTracing.create(httpTracing).build(clientBuilder);
+
+    s3Client = AwsClientTracing.create(httpTracing).build(AmazonS3ClientBuilder.standard()
+        .withCredentials(
+            new AWSStaticCredentialsProvider(new BasicAWSCredentials("access", "secret")))
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration(s3Server.url(), "us-east-1"))
+        .enableForceGlobalBucketAccess());
+  }
+
+  @After
+  public void cleanup() {
+    Tracing.current().close();
+  }
 
   @Test
   public void testSpanCreatedAndTagsApplied() throws InterruptedException {
     dynamoDBServer.enqueue(createDeleteItemResponse());
 
-    client.deleteItem("test", Collections.singletonMap("key", new AttributeValue("value")));
+    dbClient.deleteItem("test", Collections.singletonMap("key", new AttributeValue("value")));
 
     Span httpSpan = spans.poll(100, TimeUnit.MILLISECONDS);
     assertThat(httpSpan.remoteServiceName()).isEqualToIgnoringCase("amazondynamodbv2");
@@ -112,6 +124,26 @@ public class AwsClientTracingTest {
         AwsClientTracing.create(httpTracing).build(AmazonDynamoDBAsyncClientBuilder.standard());
   }
 
+  @Test
+  public void testInternalAwsRequestsDoNotThrowNPE() throws InterruptedException {
+    // Responds to the internal HEAD request
+    s3Server.enqueue(new MockResponse()
+        .setResponseCode(400)
+        .addHeader("x-amz-request-id", "abcd"));
+
+    s3Server.enqueue(getExistsResponse());
+
+    s3Client.doesBucketExistV2("Test-Bucket");
+
+    Span httpSpan = spans.poll(100, TimeUnit.MILLISECONDS);
+    assertThat(httpSpan.remoteServiceName()).isEqualToIgnoringCase("amazon s3");
+    assertThat(httpSpan.name()).isEqualToIgnoringCase("getbucketacl");
+    assertThat(httpSpan.tags().get("aws.request_id")).isEqualToIgnoringCase("abcd");
+
+    Span sdkSpan = spans.poll(100, TimeUnit.MILLISECONDS);
+    assertThat(sdkSpan.name()).isEqualToIgnoringCase("aws-sdk");
+  }
+
   private MockResponse createDeleteItemResponse() {
     MockResponse response = new MockResponse();
     response.setBody("{}");
@@ -129,4 +161,26 @@ public class AwsClientTracingTest {
                 .build())
         .sampler(Sampler.ALWAYS_SAMPLE);
   }
+
+  private MockResponse getExistsResponse() {
+    return new MockResponse().setBody("<AccessControlPolicy>\n"
+        + "  <Owner>\n"
+        + "    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>\n"
+        + "    <DisplayName>CustomersName@amazon.com</DisplayName>\n"
+        + "  </Owner>\n"
+        + "  <AccessControlList>\n"
+        + "    <Grant>\n"
+        + "      <Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+        + "\t\t\txsi:type=\"CanonicalUser\">\n"
+        + "        <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>\n"
+        + "        <DisplayName>CustomersName@amazon.com</DisplayName>\n"
+        + "      </Grantee>\n"
+        + "      <Permission>FULL_CONTROL</Permission>\n"
+        + "    </Grant>\n"
+        + "  </AccessControlList>\n"
+        + "</AccessControlPolicy> ")
+        .setResponseCode(200)
+        .addHeader("x-amz-request-id", "abcd");
+  }
+
 }

--- a/brave-instrumentation/aws-java-sdk-core/src/test/java/brave/instrumentation/aws/MockS3Server.java
+++ b/brave-instrumentation/aws-java-sdk-core/src/test/java/brave/instrumentation/aws/MockS3Server.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.instrumentation.aws;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class MockS3Server implements TestRule {
+
+  private final MockWebServer delegate = new MockWebServer();
+
+  public String url() {
+    return "http://localhost:" + delegate.getPort();
+  }
+
+  void enqueue(MockResponse mockResponse) {
+    delegate.enqueue(mockResponse);
+  }
+
+  @Override public Statement apply(Statement statement, Description description) {
+    return delegate.apply(statement, description);
+  }
+}


### PR DESCRIPTION
When an s3 client is configured with the option `enableForceGlobalBucketAccess()`, the sdk makes some internal requests that don't properly setup a parent span usually named `aws-sdk`. 

Unfortunately, I wasn't able to figure out a way to tie the "orphaned" request spans back to the original parent application spans, so null checks was the best I could do here.