### PR TITLE
Add tests for XrayUDPStorage / Reporter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.zipkin.zipkin2</groupId>
         <artifactId>zipkin</artifactId>
         <version>${zipkin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
     <!-- This allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>0.98.3</armeria.version>
+
+    <!-- Generally best to match this with armeria's dependency -->
+    <netty.version>4.1.46.Final</netty.version>
+
     <zipkin.version>2.20.0</zipkin.version>
     <zipkin-reporter.version>2.12.1</zipkin-reporter.version>
     <brave.version>5.9.1</brave.version>

--- a/reporter-xray-udp/pom.xml
+++ b/reporter-xray-udp/pom.xml
@@ -39,5 +39,15 @@
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-reporter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/reporter-xray-udp/src/test/java/zipkin2/storage/xray_udp/InternalStorageAccess.java
+++ b/reporter-xray-udp/src/test/java/zipkin2/storage/xray_udp/InternalStorageAccess.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.storage.xray_udp;
+
+import zipkin2.Span;
+
+/**
+ * Classpath accessor to expose package-private methods in the storage.
+ */
+public final class InternalStorageAccess {
+  /** Encode a span for XRay, */
+  public static byte[] encode(Span span) {
+    return UDPMessageEncoder.encode(span);
+  }
+}

--- a/storage-xray-udp/pom.xml
+++ b/storage-xray-udp/pom.xml
@@ -57,15 +57,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 </project>

--- a/storage-xray-udp/pom.xml
+++ b/storage-xray-udp/pom.xml
@@ -46,5 +46,26 @@
       <version>2.4.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-tests</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/XRayUDPStorageTest.java
+++ b/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/XRayUDPStorageTest.java
@@ -66,7 +66,7 @@ public class XRayUDPStorageTest {
     serverChannel = bootstrap.bind(0).syncUninterruptibly().channel();
 
     storage = XRayUDPStorage.newBuilder()
-        .address("localhost:" + ((InetSocketAddress)serverChannel.localAddress()).getPort())
+        .address("localhost:" + ((InetSocketAddress) serverChannel.localAddress()).getPort())
         .build();
   }
 

--- a/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/XRayUDPStorageTest.java
+++ b/storage-xray-udp/src/test/java/zipkin2/storage/xray_udp/XRayUDPStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,4 +13,108 @@
  */
 package zipkin2.storage.xray_udp;
 
-public class XRayUDPStorageTest {}
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import zipkin2.Span;
+import zipkin2.TestObjects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class XRayUDPStorageTest {
+
+  private static EventLoopGroup workerGroup;
+  private static Channel serverChannel;
+  private static BlockingQueue<byte[]> receivedPayloads;
+
+  private static XRayUDPStorage storage;
+
+  @BeforeClass
+  public static void startServer() {
+    workerGroup = new NioEventLoopGroup();
+    receivedPayloads = new LinkedBlockingQueue<>();
+
+    Bootstrap bootstrap = new Bootstrap();
+    bootstrap.group(workerGroup)
+        .channel(NioDatagramChannel.class)
+        .handler(new ChannelInitializer<NioDatagramChannel>() {
+          @Override protected void initChannel(NioDatagramChannel channel) {
+            channel.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
+              @Override protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+                receivedPayloads.add(ByteBufUtil.getBytes(msg.content()));
+              }
+            });
+          }
+        });
+
+    serverChannel = bootstrap.bind(0).syncUninterruptibly().channel();
+
+    storage = XRayUDPStorage.newBuilder()
+        .address("localhost:" + ((InetSocketAddress)serverChannel.localAddress()).getPort())
+        .build();
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    storage.close();
+    serverChannel.close().syncUninterruptibly();
+    workerGroup.shutdownGracefully();
+  }
+
+  @Before
+  public void setUp() {
+    receivedPayloads.clear();
+  }
+
+  @Test
+  public void sendTrace() throws Exception {
+    storage.accept(TestObjects.TRACE).execute();
+    for (Span span : TestObjects.TRACE) {
+      byte[] received = receivedPayloads.take();
+      assertThat(received).containsExactly(UDPMessageEncoder.encode(span));
+    }
+    assertThat(receivedPayloads).isEmpty();
+  }
+
+  @Test
+  public void sendSingleSpan() throws Exception {
+    storage.accept(Collections.singletonList(TestObjects.CLIENT_SPAN)).execute();
+    assertThat(receivedPayloads.take())
+        .containsExactly(UDPMessageEncoder.encode(TestObjects.CLIENT_SPAN));
+    assertThat(receivedPayloads).isEmpty();
+  }
+
+  @Test
+  public void sendNoSpans() throws Exception {
+    storage.accept(Collections.emptyList()).execute();
+    // Give some time for any potential bugs to get sent to the server.
+    Thread.sleep(100);
+    assertThat(receivedPayloads).isEmpty();
+  }
+
+  @Test
+  public void sendAfterClose() throws Exception {
+    XRayUDPStorage storage = XRayUDPStorage.newBuilder()
+        .address("localhost:" + ((InetSocketAddress)serverChannel.localAddress()).getPort())
+        .build();
+    storage.close();
+    assertThatThrownBy(() -> storage.accept(TestObjects.TRACE))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}


### PR DESCRIPTION
I was randomly looking at the xray storage and want to convert to using Netty to likely improve performance a lot. But that would require benchmarking and reasoning about whether adding a dependency on Netty is OK (I guess so since other storage like elasticsearch has it).

In the meantime, it shouldn't require reasoning to use Netty for tests, which would help in the event we make a change to the storage implementation.