### PR TITLE
Only use single client span for AWS SDK tracing because it is not cur…

### DIFF
--- a/brave-instrumentation/aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
@@ -74,12 +74,18 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
     return request.build();
   }
 
+  /**
+   * Before sending an http request. Will be called multiple times in the case of retries.
+   */
   @Override public void beforeTransmission(Context.BeforeTransmission context,
       ExecutionAttributes executionAttributes) {
     Span span = executionAttributes.getAttribute(SPAN);
     span.annotate("ws");
   }
 
+  /**
+   * After sending an http request. Will be called multiple times in the case of retries.
+   */
   @Override public void afterTransmission(Context.AfterTransmission context,
       ExecutionAttributes executionAttributes) {
     Span span = executionAttributes.getAttribute(SPAN);

--- a/brave-instrumentation/aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
@@ -77,7 +77,8 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
   }
 
   /**
-   * Before an individual http request happens, may be run multiple times if retries occur
+   * Before an individual http request is finalized. This is only called once per operation, meaning
+   * we can only have one span per operation.
    */
   @Override public SdkHttpRequest modifyHttpRequest(
       Context.ModifyHttpRequest context,

--- a/brave-instrumentation/aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
@@ -65,11 +65,10 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
 
     String serviceName = executionAttributes.getAttribute(SdkExecutionAttribute.SERVICE_NAME);
     String operation = getAwsOperationNameFromRequestClass(context.request());
-    span.name("aws-sdk")
+    span.name(operation)
+        .remoteServiceName(serviceName)
         .tag("aws.service_name", serviceName)
         .tag("aws.operation", operation);
-
-    span.name(operation).remoteServiceName(serviceName);
 
     return request.build();
   }
@@ -80,6 +79,10 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override public void beforeTransmission(Context.BeforeTransmission context,
       ExecutionAttributes executionAttributes) {
     Span span = executionAttributes.getAttribute(SPAN);
+    if (span == null) {
+      // An evil interceptor deleted our attribute.
+      return;
+    }
     span.annotate("ws");
   }
 
@@ -89,6 +92,10 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override public void afterTransmission(Context.AfterTransmission context,
       ExecutionAttributes executionAttributes) {
     Span span = executionAttributes.getAttribute(SPAN);
+    if (span == null) {
+      // An evil interceptor deleted our attribute.
+      return;
+    }
     span.annotate("wr");
   }
 
@@ -100,6 +107,10 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
       ExecutionAttributes executionAttributes
   ) {
     Span span = executionAttributes.getAttribute(SPAN);
+    if (span == null) {
+      // An evil interceptor deleted our attribute.
+      return;
+    }
     handler.handleReceive(new HttpClientResponse(context.httpResponse()), null, span);
   }
 
@@ -111,6 +122,10 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
       ExecutionAttributes executionAttributes
   ) {
     Span span = executionAttributes.getAttribute(SPAN);
+    if (span == null) {
+      // An evil interceptor deleted our attribute.
+      return;
+    }
     handler.handleReceive(null, context.exception(), span);
   }
 

--- a/brave-instrumentation/aws-java-sdk-v2-core/src/test/java/brave/instrumentation/awsv2/ITTracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-v2-core/src/test/java/brave/instrumentation/awsv2/ITTracingExecutionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,24 +13,16 @@
  */
 package brave.instrumentation.awsv2;
 
-import brave.ScopedSpan;
 import brave.SpanCustomizer;
-import brave.Tracer;
 import brave.http.HttpAdapter;
 import brave.http.HttpClientParser;
-import brave.internal.HexCodec;
-import brave.propagation.CurrentTraceContext;
-import brave.propagation.TraceContext;
 import brave.test.http.ITHttpClient;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Ignore;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -45,9 +37,9 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import zipkin2.Annotation;
 import zipkin2.Span;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ITTracingExecutionInterceptor extends ITHttpClient<DynamoDbClient> {
@@ -132,90 +124,13 @@ public class ITTracingExecutionInterceptor extends ITHttpClient<DynamoDbClient> 
     server.enqueue(new MockResponse());
     get(client, uri);
 
-    List<Span> spans = asList(takeSpan(), takeSpan());
-    spans.stream().filter(s -> s.parentId() != null).forEach(s -> {
-      assertThat(s.remoteServiceName())
-          .isEqualTo("dynamodb");
-      assertThat(s.name()).isEqualTo("getitem");
-
-      assertThat(s.tags())
-          .containsEntry("http.url", url(uri))
-          .containsEntry("request_customizer.is_span", "false")
-          .containsEntry("response_customizer.is_span", "false");
-    });
-  }
-
-  /** Modified to check hierarchy from parent->application->client */
-  @Override public void makesChildOfCurrentSpan() throws Exception {
-    Tracer tracer = httpTracing.tracing().tracer();
-    server.enqueue(new MockResponse());
-
-    ScopedSpan parent = tracer.startScopedSpan("test");
-    try {
-      get(client, "/foo");
-    } finally {
-      parent.finish();
-    }
-
-    List<Span> spans = asList(takeSpan(), takeSpan(), takeSpan());
-    Span applicationSpan = spans.stream()
-        .filter(s -> HexCodec.toLowerHex(parent.context().spanId()).equals(s.parentId()))
-        .findFirst()
-        .get();
-    Span clientSpan =
-        spans.stream().filter(s -> applicationSpan.id().equals(s.parentId())).findFirst().get();
-
-    RecordedRequest request = server.takeRequest();
-    assertThat(request.getHeader("x-b3-traceId"))
-        .isEqualTo(parent.context().traceIdString());
-    assertThat(request.getHeader("x-b3-parentspanid"))
-        .isEqualTo(applicationSpan.id());
-    assertThat(request.getHeader("x-b3-spanid"))
-        .isEqualTo(clientSpan.id());
-
-    assertThat(spans)
-        .extracting(Span::kind)
-        .containsOnly(null, Span.Kind.CLIENT, null);
-  }
-
-  @Override public void propagatesSpan() throws Exception {
-    super.propagatesSpan();
-    takeSpan();
-  }
-
-  @Override @Test public void propagates_sampledFalse() throws Exception {
-    server.enqueue(new MockResponse());
-    try (CurrentTraceContext.Scope ignored = httpTracing.tracing().currentTraceContext().newScope(
-        TraceContext.newBuilder().traceId(1).spanId(1).sampled(false).build())) {
-      get(client, "baz");
-    }
-
-    RecordedRequest request = server.takeRequest();
-    assertThat(request.getHeaders().toMultimap())
-        .containsKeys("x-b3-traceId", "x-b3-spanId")
-        // .doesNotContainKey("x-b3-parentSpanId") AWS SDK tracing uses 2 spans, so there is a parent
-        .containsEntry("x-b3-sampled", asList("0"));
-  }
-
-  @Override @Test public void addsErrorTagOnTransportException() throws Exception {
-    super.addsErrorTagOnTransportException();
-    Span applicationSpan = takeSpan();
-    assertThat(applicationSpan.kind()).isNull();
-    assertThat(applicationSpan.tags()).containsKey("error");
-  }
-
-  // This fails with NPE as we clear the client span on fail. on retry it isn't there anymore.
-  // we should test that the client span IDs are different and match headers sent
-  @Test @Ignore("TODO: we haven't properly addressed multiple client spans yet")
-  public void retriesAreChildrenOfApplicationSpan() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(500));
-    server.enqueue(new MockResponse());
-
-    get(client, "doo");
-
-    Span client1 = takeSpan(), client2 = takeSpan(), applicationSpan = takeSpan();
-    assertThat(applicationSpan.kind()).isNull();
-    assertThat(applicationSpan.tags()).containsKey("error");
+    Span span = takeSpan();
+    assertThat(span.remoteServiceName()).isEqualTo("dynamodb");
+    assertThat(span.name()).isEqualTo("getitem");
+    assertThat(span.tags())
+        .containsEntry("http.url", url(uri))
+        .containsEntry("request_customizer.is_span", "false")
+        .containsEntry("response_customizer.is_span", "false");
   }
 
   /** Body's inherently have a structure, and we use the operation name as the span name */
@@ -234,29 +149,22 @@ public class ITTracingExecutionInterceptor extends ITHttpClient<DynamoDbClient> 
         .isEqualTo("dynamodb");
     assertThat(span.name())
         .isEqualTo("putitem");
-
-    // application span
-    span = takeSpan();
-    assertThat(span.name()).isEqualTo("aws-sdk");
     assertThat(span.tags().get("aws.service_name"))
         .isEqualTo("DynamoDb");
     assertThat(span.tags().get("aws.operation"))
         .isEqualTo("PutItem");
   }
 
-  @Override public void propagatesExtra_newTrace() throws Exception {
-    super.propagatesExtra_newTrace();
-    takeSpan();
-  }
-
-  @Override public void reportsClientKindToZipkin() throws Exception {
-    super.reportsClientKindToZipkin();
-    takeSpan();
-  }
-
-  @Override public void reportsSpanOnTransportException() throws Exception {
-    super.reportsSpanOnTransportException();
-    takeSpan();
+  /** Make sure retry attempts are all annotated in the span. */
+  @Test public void retriesAnnotated() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse());
+    get(client, "/");
+    Span span = takeSpan();
+    assertThat(span.remoteServiceName()).isEqualTo("dynamodb");
+    assertThat(span.name()).isEqualTo("getitem");
+    assertThat(span.annotations()).extracting(Annotation::value)
+        .containsExactly("ws", "wr", "ws", "wr");
   }
 
   /*

--- a/brave-instrumentation/aws-java-sdk-v2-core/src/test/java/brave/instrumentation/awsv2/ITTracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-v2-core/src/test/java/brave/instrumentation/awsv2/ITTracingExecutionInterceptor.java
@@ -165,6 +165,12 @@ public class ITTracingExecutionInterceptor extends ITHttpClient<DynamoDbClient> 
     assertThat(span.name()).isEqualTo("getitem");
     assertThat(span.annotations()).extracting(Annotation::value)
         .containsExactly("ws", "wr", "ws", "wr");
+
+    // Ensure all requests have the injected headers.
+    assertThat(server.takeRequest().getHeader("x-b3-spanid"))
+        .isEqualTo(span.id());
+    assertThat(server.takeRequest().getHeader("x-b3-spanid"))
+        .isEqualTo(span.id());
   }
 
   /*


### PR DESCRIPTION
…rently possible to have multiple modeling retries.

Instead of multiple spans, we have annotations for each transmission attempt.

Fixes #158 