### PR TITLE
Remove port from authority header since we remove it when signing.

### DIFF
--- a/module/storage-elasticsearch-aws/src/main/java/zipkin/module/storage/elasticsearch/aws/ElasticsearchDomainEndpoint.java
+++ b/module/storage-elasticsearch-aws/src/main/java/zipkin/module/storage/elasticsearch/aws/ElasticsearchDomainEndpoint.java
@@ -23,7 +23,6 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import io.netty.util.AttributeKey;
 import java.io.IOException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
Every other release of Armeria seems to have different behavior with regards to authority header /cc @trustin

Fixes #152 