### PR TITLE
refs #174: adds AWS SDK V2 instrumentation support for SQS messages

### DIFF
--- a/brave-instrumentation/aws-java-sdk-sqs-v2/README.md
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/README.md
@@ -1,0 +1,36 @@
+# AWS SQS V2 Messaging Instrumentation
+
+This module contains instrumentation for the AWS `SqsClient` client `SendMessage*` request types
+to add Brave span information into the message attributes of the SQS message.  This allows
+consuming services to continue the trace allowing better visibility on how information is
+flowing through your services.
+
+There are two `ExecutionInterceptors` that can be included in the `SqsClient` to provide tracing
+information based on your needs:
+- [SendMessageTracingExecutionInterceptor](./src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingExecutionInterceptor.java):
+which hooks into the `sendMessage` request.
+-  [SendMessageBatchTracingExecutionInterceptor](./src/main/java/brave/instrumentation/aws/sqs/SendMessageBatchTracingExecutionInterceptor.java):
+which hooks into the `sendMessageBatch` request.
+
+## Usage
+
+You will want to create your SQS client and add the request handler
+
+```java
+Tracing tracing = ...;
+SqsAsyncClient sqsAsyncClient = SqsAsyncClient.builder()
+         // configuration for your client
+        .overrideConfiguration(builder -> {
+          builder.addExecutionInterceptor(new SendMessageTracingExecutionInterceptor(tracing));
+          builder.addExecutionInterceptor(new SendMessageBatchTracingExecutionInterceptor(tracing));
+        )
+        .build();
+```
+
+Now use your SQS client as you normally would and spans will be attached to outgoing messages.
+
+### Customizing the Span
+The interceptors have their default logic for applying certain tags to the span but if you wish
+to provide your own logic you can provide your own `SpanDecorator` implementation which supplies
+callbacks to certain events in the message publishing. See each interceptor for more information
+about the events that you can hook into.

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/pom.xml
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2020 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>brave-instrumentation-parent</artifactId>
+        <groupId>io.zipkin.aws</groupId>
+        <version>0.21.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>brave-instrumentation-aws-java-sdk-sqs-v2</artifactId>
+
+    <properties>
+        <main.java.version>1.8</main.java.version>
+        <main.signature.artifact>java18</main.signature.artifact>
+
+        <main.basedir>${project.basedir}/../..</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticmq</groupId>
+            <artifactId>elasticmq-rest-sqs_2.12</artifactId>
+            <version>0.15.6</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/src/main/java/brave/instrumentation/aws/sqs/SendMessageBatchTracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/src/main/java/brave/instrumentation/aws/sqs/SendMessageBatchTracingExecutionInterceptor.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package brave.instrumentation.aws.sqs;
+
+import brave.Span;
+import brave.Tracing;
+import brave.instrumentation.aws.sqs.propogation.SendMessageRemoteSetter;
+import brave.propagation.TraceContext;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * {@link ExecutionInterceptor} that is used to create spans for the {@link SendMessageBatchRequest}
+ * and each individual message in the request.
+ *
+ * <p>Information about each message's span is included in the message attributes of the message
+ * for consumers to continue the trace.
+ */
+public class SendMessageBatchTracingExecutionInterceptor implements ExecutionInterceptor {
+  static final ExecutionAttribute<Map<String, Span>> MESSAGE_SPANS_EXECUTION_ATTRIBUTE =
+      new ExecutionAttribute<>("message-spans");
+
+  private final Tracing tracing;
+  private final SpanDecorator spanDecorator;
+  private final TraceContext.Injector<Map<String, MessageAttributeValue>> messageAttributeInjector;
+
+  public SendMessageBatchTracingExecutionInterceptor(final Tracing tracing) {
+    this(tracing, SpanDecorator.DEFAULT);
+  }
+
+  public SendMessageBatchTracingExecutionInterceptor(final Tracing tracing,
+      final SpanDecorator spanDecorator) {
+    this(tracing, spanDecorator, SendMessageRemoteSetter.create(tracing));
+  }
+
+  public SendMessageBatchTracingExecutionInterceptor(final Tracing tracing,
+      final SpanDecorator spanDecorator,
+      final TraceContext.Injector<Map<String, MessageAttributeValue>> injector) {
+    this.tracing = tracing;
+    this.spanDecorator = spanDecorator;
+    this.messageAttributeInjector = injector;
+  }
+
+  @Override
+  public void beforeExecution(final Context.BeforeExecution context,
+      final ExecutionAttributes executionAttributes) {
+    if (!(context.request() instanceof SendMessageBatchRequest)) {
+      return;
+    }
+
+    final SendMessageBatchRequest request = (SendMessageBatchRequest) context.request();
+    final Map<String, Span> messageSpans = request.entries().stream()
+        .collect(
+            toMap(SendMessageBatchRequestEntry::id, entry -> startSpanForMessage(request, entry)));
+
+    executionAttributes.putAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE, messageSpans);
+  }
+
+  @Override
+  public SdkRequest modifyRequest(final Context.ModifyRequest context,
+      final ExecutionAttributes executionAttributes) {
+    if (!(context.request() instanceof SendMessageBatchRequest)) {
+      return context.request();
+    }
+
+    final Map<String, Span> messageSpans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    if (messageSpans == null) {
+      // someone deleted our attribute...
+      return context.request();
+    }
+
+    final SendMessageBatchRequest request = (SendMessageBatchRequest) context.request();
+    final List<SendMessageBatchRequestEntry> updatedEntries = request.entries().stream()
+        .map(requestEntry -> injectSpanInformationIntoMessage(requestEntry,
+            messageSpans.get(requestEntry.id())))
+        .collect(Collectors.toList());
+
+    return request.toBuilder()
+        .entries(updatedEntries)
+        .build();
+  }
+
+  @Override
+  public void afterExecution(final Context.AfterExecution context,
+      final ExecutionAttributes executionAttributes) {
+    if (!(context.request() instanceof SendMessageBatchRequest)) {
+      return;
+    }
+
+    final SendMessageBatchRequest request = (SendMessageBatchRequest) context.request();
+
+    final Map<String, Span> individualMessageSpans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    if (individualMessageSpans == null) {
+      // someone deleted our attribute...
+      return;
+    }
+
+    if (!context.httpResponse().isSuccessful()) {
+      individualMessageSpans.values()
+          .forEach(
+              span -> {
+                try {
+                  spanDecorator.decorateRequestFailedMessageSpan(request,
+                      context.httpResponse(), span);
+                  span.error(new RuntimeException("Error placing message onto SQS queue"));
+                } finally {
+                  span.finish();
+                }
+              });
+      return;
+    }
+
+    final SendMessageBatchResponse response = (SendMessageBatchResponse) context.response();
+
+    response.successful().forEach(result -> {
+      final Span messageSpan = individualMessageSpans.get(result.id());
+      if (messageSpan == null) {
+        // for some reason the individual message's span cannot be found
+        return;
+      }
+
+      try {
+        spanDecorator.decorateMessageSuccessfulSpan(response, context.httpResponse(),
+            result, messageSpan);
+      } finally {
+        messageSpan.finish();
+      }
+    });
+
+    response.failed().forEach(result -> {
+      final Span messageSpan = individualMessageSpans.get(result.id());
+      if (messageSpan == null) {
+        // for some reason the individual message's span cannot be found
+        return;
+      }
+
+      try {
+        spanDecorator.decorateMessageFailureSpan(response, context.httpResponse(), result,
+            messageSpan);
+        messageSpan.error(new RuntimeException("Error placing message onto SQS queue"));
+      } finally {
+        messageSpan.finish();
+      }
+    });
+  }
+
+  private Span startSpanForMessage(final SendMessageBatchRequest request,
+      final SendMessageBatchRequestEntry requestEntry) {
+    final Span messageSpan = tracing.tracer().nextSpan();
+    if (!messageSpan.isNoop()) {
+      spanDecorator.decorateMessageSpan(request, requestEntry, messageSpan);
+    }
+
+    messageSpan.start();
+    return messageSpan;
+  }
+
+  private SendMessageBatchRequestEntry injectSpanInformationIntoMessage(
+      final SendMessageBatchRequestEntry entry, final Span span) {
+    final Map<String, MessageAttributeValue> currentMessageAttributes =
+        new HashMap<>(entry.messageAttributes());
+
+    messageAttributeInjector.inject(span.context(), currentMessageAttributes);
+
+    return entry.toBuilder()
+        .messageAttributes(currentMessageAttributes)
+        .build();
+  }
+
+  /**
+   * Decorator that can be used to override the default span configurations, otherwise the {@link
+   * SpanDecorator#DEFAULT} can be used.
+   *
+   * <p>This would be helpful if you want to send extra information or remove some of the tags
+   * being sent as they are not relevant for your use case.
+   */
+  @SuppressWarnings("unused")
+  public interface SpanDecorator {
+    SpanDecorator DEFAULT = new SpanDecorator() {
+    };
+
+    /**
+     * Decorate the message span before the message is sent to SQS.
+     *
+     * @param request the original request
+     * @param entry   the entry for the message being handled
+     * @param span    the span corresponding to this message
+     */
+    default void decorateMessageSpan(final SendMessageBatchRequest request,
+        final SendMessageBatchRequestEntry entry,
+        final Span span) {
+      span.kind(Span.Kind.PRODUCER);
+      span.name("sqs-send-message-batch");
+      span.remoteServiceName("aws-sqs");
+      span.tag("queue.url", request.queueUrl());
+      span.tag("message.request.id", entry.id());
+    }
+
+    /**
+     * Decorator called for each message when the entire HTTP request to SQS fails.
+     *
+     * @param request      the request that was sent to SQS
+     * @param httpResponse the http response that indicates the failure
+     * @param span         the span to apply decorations to
+     */
+    default void decorateRequestFailedMessageSpan(final SendMessageBatchRequest request,
+        final SdkHttpResponse httpResponse,
+        final Span span) {
+      span.tag("response.code", String.valueOf(httpResponse.statusCode()));
+    }
+
+    /**
+     * Decorator called for each message that was successfully published to SQS.
+     *
+     * @param response     the response for the request
+     * @param httpResponse the underlying http response
+     * @param entry        the message entry that was a success
+     * @param span         the span corresponding to this message
+     */
+    default void decorateMessageSuccessfulSpan(final SendMessageBatchResponse response,
+        final SdkHttpResponse httpResponse,
+        final SendMessageBatchResultEntry entry,
+        final Span span) {
+      span.tag("message.id", entry.messageId());
+    }
+
+    /**
+     * Decorator called for each message that failed to be published to SQS.
+     *
+     * <p>Note that this is only called if the underlying HTTP was a success but individual
+     * messages failed to be processed.
+     *
+     * @param response     the response for the request
+     * @param httpResponse the underlying http response
+     * @param entry        the message entry that was a failure
+     * @param span         the span corresponding to this message
+     */
+    default void decorateMessageFailureSpan(final SendMessageBatchResponse response,
+        final SdkHttpResponse httpResponse,
+        final BatchResultErrorEntry entry,
+        final Span span) {
+    }
+  }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingExecutionInterceptor.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.instrumentation.aws.sqs;
+
+import brave.Span;
+import brave.Tracing;
+import brave.instrumentation.aws.sqs.propogation.SendMessageRemoteSetter;
+import brave.propagation.TraceContext;
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+/**
+ * {@link ExecutionInterceptor} that will add tracing information to the message attributes of a SQS
+ * message placed onto the queue.
+ *
+ * <p>This will allow the trace to be continued by all consuming services.
+ */
+public class SendMessageTracingExecutionInterceptor implements ExecutionInterceptor {
+  static final ExecutionAttribute<Span> SPAN_EXECUTION_ATTRIBUTE = new ExecutionAttribute<>("span");
+
+  private final Tracing tracing;
+  private final TraceContext.Injector<Map<String, MessageAttributeValue>> messageAttributeInjector;
+  private final SpanDecorator spanDecorator;
+
+  public SendMessageTracingExecutionInterceptor(final Tracing tracing) {
+    this(tracing, SpanDecorator.DEFAULT);
+  }
+
+  public SendMessageTracingExecutionInterceptor(final Tracing tracing,
+      final SpanDecorator spanDecorator) {
+    this(tracing, spanDecorator, SendMessageRemoteSetter.create(tracing));
+  }
+
+  public SendMessageTracingExecutionInterceptor(final Tracing tracing,
+      final SpanDecorator spanDecorator,
+      final TraceContext.Injector<Map<String, MessageAttributeValue>> injector) {
+    this.tracing = tracing;
+    this.spanDecorator = spanDecorator;
+    this.messageAttributeInjector = injector;
+  }
+
+  @Override
+  public void beforeExecution(final Context.BeforeExecution context,
+      final ExecutionAttributes executionAttributes) {
+    if (!(context.request() instanceof SendMessageRequest)) {
+      return;
+    }
+
+    final Span span = tracing.tracer().nextSpan();
+
+    if (!span.isNoop()) {
+      spanDecorator.decorateMessageSpan((SendMessageRequest) context.request(), span);
+    }
+    span.start();
+
+    executionAttributes.putAttribute(SPAN_EXECUTION_ATTRIBUTE, span);
+  }
+
+  @Override
+  public SdkRequest modifyRequest(final Context.ModifyRequest context,
+      final ExecutionAttributes executionAttributes) {
+    if (!(context.request() instanceof SendMessageRequest)) {
+      return context.request();
+    }
+    final SendMessageRequest request = (SendMessageRequest) context.request();
+
+    final Span span = executionAttributes.getAttribute(SPAN_EXECUTION_ATTRIBUTE);
+    if (span == null) {
+      // someone deleted our attribute...
+      return request;
+    }
+
+    final Map<String, MessageAttributeValue> currentMessageAttributes =
+        new HashMap<>(request.messageAttributes());
+    messageAttributeInjector.inject(span.context(), currentMessageAttributes);
+
+    return request.toBuilder()
+        .messageAttributes(currentMessageAttributes)
+        .build();
+  }
+
+  @Override
+  public void afterExecution(final Context.AfterExecution context,
+      final ExecutionAttributes executionAttributes) {
+    if (!(context.request() instanceof SendMessageRequest)) {
+      return;
+    }
+
+    final Span span = executionAttributes.getAttribute(SPAN_EXECUTION_ATTRIBUTE);
+    if (span == null) {
+      // someone deleted our attribute...
+      return;
+    }
+
+    try {
+      final SendMessageRequest request = (SendMessageRequest) context.request();
+      final SendMessageResponse response = (SendMessageResponse) context.response();
+      if (context.httpResponse().isSuccessful()) {
+        spanDecorator.decorateMessageSpanOnSuccess(request, response,
+            context.httpResponse(), span);
+      } else {
+        spanDecorator.decorateMessageSpanOnFailure(request, response,
+            context.httpResponse(), span);
+        span.error(new RuntimeException("Error placing message onto SQS queue"));
+      }
+    } finally {
+      span.finish();
+    }
+  }
+
+  /**
+   * Decorator that can be used to override the default span configurations, otherwise the {@link
+   * SendMessageTracingExecutionInterceptor.SpanDecorator#DEFAULT} can be used.
+   *
+   * <p>This would be helpful if you want to send extra information or remove some of the tags
+   * being sent as they are not relevant for your use case.
+   */
+  @SuppressWarnings("unused") public interface SpanDecorator {
+    SpanDecorator DEFAULT = new SpanDecorator() {
+    };
+
+    /**
+     * Decorate the message span before the message is sent to SQS.
+     *
+     * @param request the original request
+     * @param span    the span corresponding to this message
+     */
+    default void decorateMessageSpan(final SendMessageRequest request,
+        final Span span) {
+      span.kind(Span.Kind.PRODUCER);
+      span.name("sqs-send-message");
+      span.remoteServiceName("aws-sqs");
+      span.tag("queue.url", request.queueUrl());
+    }
+
+    /**
+     * Decorate the message span when the message was successfully published to SQS.
+     *
+     * @param request         the request published to SQS
+     * @param response        the response received
+     * @param sdkHttpResponse the underlying HTTP response
+     * @param span            the span for this message to decorate
+     */
+    default void decorateMessageSpanOnSuccess(final SendMessageRequest request,
+        final SendMessageResponse response,
+        final SdkHttpResponse sdkHttpResponse,
+        final Span span) {
+      span.tag("message.id", response.messageId());
+    }
+
+    /**
+     * Decorate the message span when the message failed to be published to SQS.
+     *
+     * @param request         the request published to SQS
+     * @param response        the response received
+     * @param sdkHttpResponse the underlying HTTP response
+     * @param span            the span for this message to decorate
+     */
+    default void decorateMessageSpanOnFailure(final SendMessageRequest request,
+        final SendMessageResponse response,
+        final SdkHttpResponse sdkHttpResponse,
+        final Span span) {
+      span.tag("response.code", String.valueOf(sdkHttpResponse.statusCode()));
+    }
+  }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/src/main/java/brave/instrumentation/aws/sqs/propogation/SendMessageRemoteGetter.java
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/src/main/java/brave/instrumentation/aws/sqs/propogation/SendMessageRemoteGetter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.instrumentation.aws.sqs.propogation;
+
+import brave.Span;
+import brave.Tracing;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+
+import static brave.Span.Kind.PRODUCER;
+
+/**
+ * Used to consume the tracing information from the message attributes of the SQS message.
+ *
+ * @see SendMessageRemoteSetter for placing this information into the message attributes
+ */
+public class SendMessageRemoteGetter
+    implements Propagation.RemoteGetter<Map<String, MessageAttributeValue>> {
+
+  @Override
+  public Span.Kind spanKind() {
+    return PRODUCER;
+  }
+
+  @Override
+  public String get(final Map<String, MessageAttributeValue> request, final String fieldName) {
+    return Optional.ofNullable(request.get(fieldName))
+        .map(MessageAttributeValue::stringValue)
+        .orElse(null);
+  }
+
+  /**
+   * Helper static function to create an extractor for this {@link Propagation.RemoteGetter}.
+   *
+   * @param tracing trace instrumentation utilities
+   * @return the extractor
+   */
+  public static TraceContext.Extractor<Map<String, MessageAttributeValue>> create(
+      final Tracing tracing) {
+    return tracing.propagation().extractor(new SendMessageRemoteGetter());
+  }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/src/main/java/brave/instrumentation/aws/sqs/propogation/SendMessageRemoteSetter.java
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/src/main/java/brave/instrumentation/aws/sqs/propogation/SendMessageRemoteSetter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.instrumentation.aws.sqs.propogation;
+
+import brave.Span;
+import brave.Tracing;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import java.util.Map;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+
+import static brave.Span.Kind.PRODUCER;
+
+/**
+ * Used to set the tracing information into the message attributes of a SQS message.
+ *
+ * @see SendMessageRemoteGetter for extraction this information from the message attributes
+ */
+public class SendMessageRemoteSetter
+    implements Propagation.RemoteSetter<Map<String, MessageAttributeValue>> {
+
+  @Override
+  public Span.Kind spanKind() {
+    return PRODUCER;
+  }
+
+  @Override
+  public void put(final Map<String, MessageAttributeValue> carrier, final String fieldName,
+      final String value) {
+    carrier.put(fieldName,
+        MessageAttributeValue.builder().dataType("String").stringValue(value).build());
+  }
+
+  /**
+   * Helper static function to create an injector for this {@link Propagation.RemoteGetter}.
+   *
+   * @param tracing trace instrumentation utilities
+   * @return the injector
+   */
+  public static TraceContext.Injector<Map<String, MessageAttributeValue>> create(
+      final Tracing tracing) {
+    return tracing.propagation().injector(new SendMessageRemoteSetter());
+  }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/src/test/java/brave/instrumentation/aws/sqs/ITSendMessageBatchTracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/src/test/java/brave/instrumentation/aws/sqs/ITSendMessageBatchTracingExecutionInterceptor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.instrumentation.aws.sqs;
+
+import akka.http.scaladsl.Http;
+import brave.ScopedSpan;
+import brave.handler.MutableSpan;
+import brave.instrumentation.aws.sqs.propogation.SendMessageRemoteGetter;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.test.ITRemote;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.elasticmq.rest.sqs.SQSRestServer;
+import org.elasticmq.rest.sqs.SQSRestServerBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+
+import static brave.Span.Kind.PRODUCER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITSendMessageBatchTracingExecutionInterceptor extends ITRemote {
+
+  private SqsAsyncClient sqsAsyncClient;
+
+  private SQSRestServer sqsRestServer;
+
+  private String queueUrl;
+
+  @Before
+  public void setUp() throws Exception {
+    sqsRestServer = SQSRestServerBuilder
+        .withInterface("localhost")
+        .withDynamicPort()
+        .start();
+
+    final Http.ServerBinding serverBinding = sqsRestServer.waitUntilStarted();
+    final String queueServerUrl = "http://localhost:" + serverBinding.localAddress().getPort();
+
+    sqsAsyncClient = SqsAsyncClient.builder()
+        .endpointOverride(URI.create(queueServerUrl))
+        .region(Region.of("elastic-mq"))
+        .credentialsProvider(StaticCredentialsProvider.create(
+            AwsBasicCredentials.create("accessKeyId", "secretAccessKey")))
+        .overrideConfiguration(builder -> builder.addExecutionInterceptor(
+            new SendMessageBatchTracingExecutionInterceptor(tracing)))
+        .build();
+
+    queueUrl = sqsAsyncClient.createQueue(builder -> builder.queueName("name"))
+        .get(5, TimeUnit.SECONDS)
+        .queueUrl();
+  }
+
+  @After
+  public void tearDown() {
+    if (sqsRestServer != null) {
+      sqsRestServer.stopAndWait();
+    }
+  }
+
+  @Test
+  public void spanInformationIsSharedOverSqsMessageAttributes()
+      throws InterruptedException, TimeoutException, ExecutionException {
+    // arrange
+    final ScopedSpan scopedSpan = tracing.tracer().startScopedSpan("test-span");
+    final List<SendMessageBatchRequestEntry> messages = new ArrayList<>();
+    messages.add(SendMessageBatchRequestEntry.builder()
+        .id("first")
+        .messageBody("body-first")
+        .build());
+    messages.add(SendMessageBatchRequestEntry.builder()
+        .id("second")
+        .messageBody("body-second")
+        .build());
+
+    // act
+    sqsAsyncClient.sendMessageBatch(builder -> builder.queueUrl(queueUrl).entries(messages))
+        .get(5, TimeUnit.SECONDS);
+
+    final ReceiveMessageResponse receiveMessageResponse =
+        sqsAsyncClient.receiveMessage(builder -> builder
+            .queueUrl(queueUrl)
+            .maxNumberOfMessages(2)
+            .waitTimeSeconds(5)
+            .messageAttributeNames("b3")
+        ).get(5, TimeUnit.SECONDS);
+    scopedSpan.finish();
+
+    // assert
+    final MutableSpan firstMessageSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
+    final MutableSpan secondMessageSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
+    final MutableSpan testSpan = testSpanHandler.takeLocalSpan();
+
+    final Message firstMessage =
+        getMessage(receiveMessageResponse, firstMessageSpan.tag("message.id"));
+    final TraceContextOrSamplingFlags firstMessageContext =
+        SendMessageRemoteGetter.create(tracing).extract(firstMessage.messageAttributes());
+    assertThat(firstMessageContext.context().traceIdString()).isEqualTo(testSpan.traceId());
+    assertThat(firstMessageContext.context().traceIdString()).isEqualTo(firstMessageSpan.traceId());
+    assertThat(firstMessageContext.context().spanIdString()).isEqualTo(firstMessageSpan.id());
+
+    final Message secondMessage =
+        getMessage(receiveMessageResponse, secondMessageSpan.tag("message.id"));
+    final TraceContextOrSamplingFlags secondMessageContext =
+        SendMessageRemoteGetter.create(tracing).extract(secondMessage.messageAttributes());
+    assertThat(secondMessageContext.context().traceIdString()).isEqualTo(testSpan.traceId());
+    assertThat(secondMessageContext.context().traceIdString()).isEqualTo(
+        secondMessageSpan.traceId());
+    assertThat(secondMessageContext.context().spanIdString()).isEqualTo(secondMessageSpan.id());
+  }
+
+  private Message getMessage(final ReceiveMessageResponse response, final String messageId) {
+    return response.messages().stream()
+        .filter(message -> message.messageId().equals(messageId))
+        .findFirst()
+        .orElseThrow(() -> new RuntimeException("Could not find message with ID: " + messageId));
+  }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/src/test/java/brave/instrumentation/aws/sqs/ITSendMessageTracingExecutionInterceptor.java
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/src/test/java/brave/instrumentation/aws/sqs/ITSendMessageTracingExecutionInterceptor.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.instrumentation.aws.sqs;
+
+import akka.http.scaladsl.Http;
+import brave.ScopedSpan;
+import brave.handler.MutableSpan;
+import brave.instrumentation.aws.sqs.propogation.SendMessageRemoteGetter;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.test.ITRemote;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import org.elasticmq.rest.sqs.SQSRestServer;
+import org.elasticmq.rest.sqs.SQSRestServerBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+import static brave.Span.Kind.PRODUCER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ITSendMessageTracingExecutionInterceptor extends ITRemote {
+
+  private SqsAsyncClient sqsAsyncClient;
+
+  private SQSRestServer sqsRestServer;
+
+  private String queueUrl;
+
+  @Before
+  public void setUp() throws Exception {
+    sqsRestServer = SQSRestServerBuilder
+        .withInterface("localhost")
+        .withDynamicPort()
+        .start();
+
+    final Http.ServerBinding serverBinding = sqsRestServer.waitUntilStarted();
+    final String queueServerUrl = "http://localhost:" + serverBinding.localAddress().getPort();
+
+    sqsAsyncClient = SqsAsyncClient.builder()
+        .endpointOverride(URI.create(queueServerUrl))
+        .region(Region.of("elastic-mq"))
+        .credentialsProvider(StaticCredentialsProvider.create(
+            AwsBasicCredentials.create("accessKeyId", "secretAccessKey")))
+        .overrideConfiguration(builder -> builder.addExecutionInterceptor(
+            new SendMessageTracingExecutionInterceptor(tracing)))
+        .build();
+
+    queueUrl = sqsAsyncClient.createQueue(builder -> builder.queueName("name"))
+        .get(5, TimeUnit.SECONDS)
+        .queueUrl();
+  }
+
+  @After
+  public void tearDown() {
+    if (sqsRestServer != null) {
+      sqsRestServer.stopAndWait();
+    }
+  }
+
+  @Test
+  public void spanInformationIsSharedOverSqsMessageAttributes() throws Exception {
+    // arrange
+    final ScopedSpan scopedSpan = tracing.tracer().startScopedSpan("test-span");
+
+    // act
+    final String messageId =
+        sqsAsyncClient.sendMessage(builder -> builder.queueUrl(queueUrl).messageBody("body"))
+            .get(5, TimeUnit.SECONDS)
+            .messageId();
+
+    final ReceiveMessageResponse receiveMessageResponse =
+        sqsAsyncClient.receiveMessage(builder -> builder
+            .queueUrl(queueUrl)
+            .waitTimeSeconds(5)
+            .messageAttributeNames("b3")
+        ).get(5, TimeUnit.SECONDS);
+    scopedSpan.finish();
+
+    // assert
+    assertThat(receiveMessageResponse.messages()).hasSize(1);
+    final Message message = receiveMessageResponse.messages().get(0);
+    assertThat(message.messageId()).isEqualTo(messageId);
+    final TraceContextOrSamplingFlags traceContextOrSamplingFlags =
+        SendMessageRemoteGetter.create(tracing).extract(message.messageAttributes());
+    final MutableSpan sendMessageSpan = testSpanHandler.takeRemoteSpan(PRODUCER);
+    final MutableSpan testSpan = testSpanHandler.takeLocalSpan();
+    assertThat(traceContextOrSamplingFlags.context().traceIdString()).isEqualTo(
+        sendMessageSpan.traceId());
+    assertThat(traceContextOrSamplingFlags.context().traceIdString()).isEqualTo(testSpan.traceId());
+  }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/src/test/java/brave/instrumentation/aws/sqs/SendMessageBatchTracingExecutionInterceptorTest.java
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/src/test/java/brave/instrumentation/aws/sqs/SendMessageBatchTracingExecutionInterceptorTest.java
@@ -1,0 +1,567 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.instrumentation.aws.sqs;
+
+import brave.ScopedSpan;
+import brave.Span;
+import brave.Tracing;
+import brave.instrumentation.aws.sqs.propogation.SendMessageRemoteGetter;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.test.TestSpanHandler;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+import static brave.instrumentation.aws.sqs.SendMessageBatchTracingExecutionInterceptor.MESSAGE_SPANS_EXECUTION_ATTRIBUTE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SendMessageBatchTracingExecutionInterceptorTest {
+  private final TestSpanHandler spanHandler = new TestSpanHandler();
+  private final Tracing tracing = Tracing.newBuilder()
+      .addSpanHandler(spanHandler)
+      .build();
+
+  private SendMessageBatchTracingExecutionInterceptor interceptor;
+
+  @Before
+  public void setUp() {
+    interceptor = new SendMessageBatchTracingExecutionInterceptor(tracing);
+  }
+
+  @After
+  public void tearDown() {
+    tracing.close();
+  }
+
+  @Test
+  public void beforeExecutionWillPerformNoActionForNonSendMessageBatchRequests() {
+    // arrange
+    final DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .receiptHandle("receiptHandle")
+        .build();
+
+    // act
+    interceptor.beforeExecution(() -> deleteMessageRequest, new ExecutionAttributes());
+
+    // assert
+    assertThat(spanHandler.spans()).isEmpty();
+  }
+
+  @Test
+  public void beforeExecutionWhenNoCurrentSpanANewOneWillBeCreatedForEachMessage() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+    // act
+    interceptor.beforeExecution(() -> request, executionAttributes);
+
+    // assert
+    final Map<String, Span> spans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    assertThat(spans).hasSize(2);
+    assertThat(spans).allSatisfy((entryId, span) -> assertThat(span.context().parentId()).isNull());
+  }
+
+  @Test
+  public void beforeExecutionWhenASpanExistsTheMessageSpanWillBeAChildOfThisSpan() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+    // act
+    final ScopedSpan parentSpan = tracing.tracer().startScopedSpan("parent");
+    try {
+      interceptor.beforeExecution(() -> request, executionAttributes);
+    } finally {
+      parentSpan.finish();
+    }
+
+    // assert
+    final Map<String, Span> spans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    assertThat(spans).hasSize(2);
+    assertThat(spans).allSatisfy((entryId, span) -> assertThat(span.context().parentId()).isEqualTo(
+        parentSpan.context().spanId()));
+  }
+
+  @Test
+  public void beforeExecutionMessageSpansWillBePopulatedWithDefaultQueueInformation() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+    // act
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Map<String, Span> spans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    spans.values().forEach(Span::finish);
+
+    // assert
+    assertThat(spanHandler.spans()).allSatisfy((span) -> {
+      assertThat(span.kind()).isEqualTo(Span.Kind.PRODUCER);
+      assertThat(span.name()).isEqualTo("sqs-send-message-batch");
+      assertThat(span.remoteServiceName()).isEqualTo("aws-sqs");
+      assertThat(span.tag("queue.url")).isEqualTo("queueUrl");
+    });
+  }
+
+  @Test
+  public void beforeExecutionRequestSpanInformationCanBeOverwritten() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    final SendMessageBatchTracingExecutionInterceptor.SpanDecorator spanDecorator =
+        new SendMessageBatchTracingExecutionInterceptor.SpanDecorator() {
+          @Override public void decorateMessageSpan(SendMessageBatchRequest request,
+              SendMessageBatchRequestEntry entry, Span span) {
+            span.tag("test", "value");
+          }
+        };
+
+    // act
+    final SendMessageBatchTracingExecutionInterceptor interceptor =
+        new SendMessageBatchTracingExecutionInterceptor(tracing, spanDecorator);
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Map<String, Span> spans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    spans.values().forEach(Span::finish);
+
+    // assert
+    assertThat(spanHandler.spans()).allSatisfy((span) -> {
+      assertThat(span.name()).isNull();
+      assertThat(span.remoteServiceName()).isNull();
+      assertThat(span.tag("test")).isEqualTo("value");
+    });
+  }
+
+  @Test
+  public void modifyRequestWillNotUpdateRequestIfNotSendMessageRequest() {
+    // arrange
+    final DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .receiptHandle("receiptHandle")
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+    // act
+    final SdkRequest newRequest =
+        interceptor.modifyRequest(() -> deleteMessageRequest, executionAttributes);
+
+    // assert
+    assertThat(newRequest).isSameAs(deleteMessageRequest);
+  }
+
+  @Test
+  public void modifyRequestWillAddSpanInformationToMessageAttributes() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final TraceContext.Extractor<Map<String, MessageAttributeValue>> extractor =
+        SendMessageRemoteGetter.create(tracing);
+
+    // act
+    final SendMessageBatchRequest newRequest =
+        (SendMessageBatchRequest) interceptor.modifyRequest(() -> request, executionAttributes);
+    final Map<String, Span> spans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    spans.values().forEach(Span::finish);
+
+    // assert
+    assertThat(newRequest.entries()).allSatisfy((entry) -> {
+      assertThat(entry.messageAttributes()).containsKeys("b3");
+      final TraceContextOrSamplingFlags traceContextOrSamplingFlags =
+          extractor.extract(entry.messageAttributes());
+      assertThat(traceContextOrSamplingFlags).isNotNull();
+      final Span entrySpan = spans.get(entry.id());
+      assertThat(traceContextOrSamplingFlags.context().traceIdString()).isEqualTo(
+          entrySpan.context().traceIdString());
+      assertThat(traceContextOrSamplingFlags.context().spanIdString()).isEqualTo(
+          entrySpan.context().spanIdString());
+    });
+  }
+
+  @Test
+  public void modifyRequestWhenSpanDeletedFromExecutionContextWillReturnOriginalRequest() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    executionAttributes.putAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE, null);
+
+    // act
+    final SendMessageBatchRequest newRequest =
+        (SendMessageBatchRequest) interceptor.modifyRequest(() -> request, executionAttributes);
+
+    // assert
+    assertThat(newRequest).isSameAs(request);
+  }
+
+  @Test
+  public void afterExecutionWillDoNothingIfNotSendMessageRequest() {
+    // arrange
+    final DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .receiptHandle("receiptHandle")
+        .build();
+    final Context.AfterExecution afterExecution =
+        mockAfterExecutionFailure(deleteMessageRequest, 400);
+    final Span span = tracing.tracer().nextSpan();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    executionAttributes.putAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE,
+        ImmutableMap.of("test", span));
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isEmpty();
+  }
+
+  @Test
+  public void afterExecutionWillDoNothingIfNotSpanIsNotPresentInExecutionAttributes() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final Context.AfterExecution afterExecution = mockAfterExecutionFailure(request, 400);
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    executionAttributes.putAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE, null);
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isEmpty();
+  }
+
+  @Test
+  public void afterExecutionWillFinishSpan() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final List<SendMessageBatchResultEntry> successfulMessages = new ArrayList<>();
+    successfulMessages.add(SendMessageBatchResultEntry.builder()
+        .id("first")
+        .messageId("first-message-id")
+        .build());
+    successfulMessages.add(SendMessageBatchResultEntry.builder()
+        .id("second")
+        .messageId("second-message-id")
+        .build());
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionSuccess(request,
+        successfulMessages, new ArrayList<>());
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isNotEmpty();
+  }
+
+  @Test
+  public void afterExecutionSuccessfulPublishingOfMessageWillIncludeMessageIdTag() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final List<SendMessageBatchResultEntry> successfulMessages = new ArrayList<>();
+    successfulMessages.add(SendMessageBatchResultEntry.builder()
+        .id("first")
+        .messageId("first-message-id")
+        .build());
+    successfulMessages.add(SendMessageBatchResultEntry.builder()
+        .id("second")
+        .messageId("second-message-id")
+        .build());
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionSuccess(request,
+        successfulMessages, new ArrayList<>());
+    final Map<String, Span> spans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    spans.values().forEach(Span::finish);
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).hasSize(2);
+    assertThat(spanHandler.spans()).anyMatch(span ->
+        span.tag("message.request.id").equals("first") && span.tag("message.id")
+            .equals("first-message-id"));
+    assertThat(spanHandler.spans()).anyMatch(span ->
+        span.tag("message.request.id").equals("second") && span.tag("message.id")
+            .equals("second-message-id"));
+  }
+
+  @Test
+  public void afterExecutionOnFailureWillErrorOutTheSpan() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionFailure(request, 400);
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).hasSize(2);
+    assertThat(spanHandler.spans()).allSatisfy(span -> {
+      assertThat(span.error()).hasMessage("Error placing message onto SQS queue");
+      assertThat(span.tag("response.code")).isEqualTo("400");
+    });
+  }
+
+  @Test
+  public void afterExecutionCustomSpanDecoratorWillRunAfterExecutionForFailures() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionFailure(request, 500);
+    final SendMessageBatchTracingExecutionInterceptor.SpanDecorator spanDecorator =
+        new SendMessageBatchTracingExecutionInterceptor.SpanDecorator() {
+          @Override
+          public void decorateRequestFailedMessageSpan(SendMessageBatchRequest request,
+              SdkHttpResponse httpResponse, Span span) {
+            span.tag("test", "value");
+          }
+        };
+
+    // act
+    final SendMessageBatchTracingExecutionInterceptor interceptor =
+        new SendMessageBatchTracingExecutionInterceptor(tracing, spanDecorator);
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).hasSize(2);
+    assertThat(spanHandler.spans()).allSatisfy(
+        span -> assertThat(span.tag("test")).isEqualTo("value"));
+  }
+
+  @Test
+  public void failureToProcessIndividualMessagesWillErrorOutThatSpan() {
+    // arrange
+    final SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(SendMessageBatchRequestEntry.builder()
+                .id("first")
+                .messageBody("body")
+                .build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("second")
+                .messageBody("body")
+                .build()
+        )
+        .build();
+    final List<SendMessageBatchResultEntry> successfulMessages = new ArrayList<>();
+    successfulMessages.add(SendMessageBatchResultEntry.builder()
+        .id("first")
+        .messageId("first-message-id")
+        .build());
+    final List<BatchResultErrorEntry> failingMessages = new ArrayList<>();
+    failingMessages.add(BatchResultErrorEntry.builder()
+        .id("second")
+        .code("some error code")
+        .build());
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionSuccess(request,
+        successfulMessages, failingMessages);
+    final Map<String, Span> spans =
+        executionAttributes.getAttribute(MESSAGE_SPANS_EXECUTION_ATTRIBUTE);
+    spans.values().forEach(Span::finish);
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).hasSize(2);
+    assertThat(spanHandler.spans()).anyMatch(span ->
+        span.tag("message.request.id").equals("first") && span.tag("message.id")
+            .equals("first-message-id"));
+    assertThat(spanHandler.spans()).anySatisfy(span -> {
+      assertThat(span.tag("message.request.id")).isEqualTo("second");
+      assertThat(span.error()).hasMessage("Error placing message onto SQS queue");
+    });
+  }
+
+  private Context.AfterExecution mockAfterExecutionSuccess(final SdkRequest request,
+      final Collection<SendMessageBatchResultEntry> successful,
+      final Collection<BatchResultErrorEntry> failed) {
+    final Context.AfterExecution afterExecution = mock(Context.AfterExecution.class);
+    final SdkHttpResponse sdkHttpResponse = mock(SdkHttpResponse.class);
+    when(afterExecution.httpResponse()).thenReturn(sdkHttpResponse);
+    when(afterExecution.request()).thenReturn(request);
+    when(sdkHttpResponse.isSuccessful()).thenReturn(true);
+    when(afterExecution.response()).thenReturn(SendMessageBatchResponse.builder()
+        .successful(successful)
+        .failed(failed)
+        .build());
+    return afterExecution;
+  }
+
+  private Context.AfterExecution mockAfterExecutionFailure(final SdkRequest request,
+      final int statusCode) {
+    final Context.AfterExecution afterExecution = mock(Context.AfterExecution.class);
+    final SdkHttpResponse sdkHttpResponse = mock(SdkHttpResponse.class);
+    when(afterExecution.httpResponse()).thenReturn(sdkHttpResponse);
+    when(afterExecution.request()).thenReturn(request);
+    when(sdkHttpResponse.isSuccessful()).thenReturn(false);
+    when(sdkHttpResponse.statusCode()).thenReturn(statusCode);
+    return afterExecution;
+  }
+}

--- a/brave-instrumentation/aws-java-sdk-sqs-v2/src/test/java/brave/instrumentation/aws/sqs/SendMessageTracingExecutionInterceptorTest.java
+++ b/brave-instrumentation/aws-java-sdk-sqs-v2/src/test/java/brave/instrumentation/aws/sqs/SendMessageTracingExecutionInterceptorTest.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.instrumentation.aws.sqs;
+
+import brave.ScopedSpan;
+import brave.Span;
+import brave.Tracing;
+import brave.handler.MutableSpan;
+import brave.instrumentation.aws.sqs.propogation.SendMessageRemoteGetter;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.test.TestSpanHandler;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+import static brave.instrumentation.aws.sqs.SendMessageTracingExecutionInterceptor.SPAN_EXECUTION_ATTRIBUTE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SendMessageTracingExecutionInterceptorTest {
+  private final TestSpanHandler spanHandler = new TestSpanHandler();
+  private final Tracing tracing = Tracing.newBuilder()
+      .addSpanHandler(spanHandler)
+      .build();
+
+  private SendMessageTracingExecutionInterceptor interceptor;
+
+  @Before
+  public void setUp() {
+    interceptor = new SendMessageTracingExecutionInterceptor(tracing);
+  }
+
+  @After
+  public void tearDown() {
+    tracing.close();
+  }
+
+  @Test
+  public void beforeExecutionWillPerformNoActionForNonSendMessageRequests() {
+    // arrange
+    final DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .receiptHandle("receiptHandle")
+        .build();
+
+    // act
+    interceptor.beforeExecution(() -> deleteMessageRequest, new ExecutionAttributes());
+
+    // assert
+    assertThat(spanHandler.spans()).isEmpty();
+  }
+
+  @Test
+  public void beforeExecutionWhenNoCurrentSpanANewOneWillBeCreatedForMessage() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+    // act
+    interceptor.beforeExecution(() -> request, executionAttributes);
+
+    // assert
+    final Span span = executionAttributes.getAttribute(SPAN_EXECUTION_ATTRIBUTE);
+    assertThat(span).isNotNull();
+    assertThat(span.context().parentId()).isNull();
+  }
+
+  @Test
+  public void beforeExecutionWhenASpanExistsTheSendMessageSpanWillBeAChildOfThisSpan() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+    // act
+    final ScopedSpan parentSpan = tracing.tracer().startScopedSpan("parent");
+    try {
+      interceptor.beforeExecution(() -> request, executionAttributes);
+    } finally {
+      parentSpan.finish();
+    }
+
+    // assert
+    final Span span = executionAttributes.getAttribute(SPAN_EXECUTION_ATTRIBUTE);
+    assertThat(span).isNotNull();
+    assertThat(span.context().parentId()).isEqualTo(parentSpan.context().spanId());
+  }
+
+  @Test
+  public void beforeExecutionSendMessageSpanWillBePopulatedWithDefaultQueueInformation() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+    // act
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Span span = executionAttributes.getAttribute(SPAN_EXECUTION_ATTRIBUTE);
+    span.finish();
+
+    // assert
+    final MutableSpan sendMessageMutableSpan = spanHandler.spans().get(0);
+    assertThat(sendMessageMutableSpan.kind()).isEqualTo(Span.Kind.PRODUCER);
+    assertThat(sendMessageMutableSpan.name()).isEqualTo("sqs-send-message");
+    assertThat(sendMessageMutableSpan.remoteServiceName()).isEqualTo("aws-sqs");
+    assertThat(sendMessageMutableSpan.tag("queue.url")).isEqualTo("queueUrl");
+  }
+
+  @Test
+  public void beforeExecutionRequestSpanInformationCanBeOverwritten() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    final SendMessageTracingExecutionInterceptor.SpanDecorator spanDecorator =
+        new SendMessageTracingExecutionInterceptor.SpanDecorator() {
+          @Override
+          public void decorateMessageSpan(SendMessageRequest request, Span span) {
+            span.tag("test", "value");
+          }
+        };
+
+    // act
+    final SendMessageTracingExecutionInterceptor interceptor =
+        new SendMessageTracingExecutionInterceptor(tracing, spanDecorator);
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Span span = executionAttributes.getAttribute(SPAN_EXECUTION_ATTRIBUTE);
+    span.finish();
+
+    // assert
+    final MutableSpan sendMessageMutableSpan = spanHandler.spans().get(0);
+    assertThat(sendMessageMutableSpan.name()).isNull();
+    assertThat(sendMessageMutableSpan.remoteServiceName()).isNull();
+    assertThat(sendMessageMutableSpan.tag("test")).isEqualTo("value");
+  }
+
+  @Test
+  public void modifyRequestWillNotUpdateRequestIfNotSendMessageRequest() {
+    // arrange
+    final DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .receiptHandle("receiptHandle")
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+
+    // act
+    final SdkRequest newRequest =
+        interceptor.modifyRequest(() -> deleteMessageRequest, executionAttributes);
+
+    // assert
+    assertThat(newRequest).isSameAs(deleteMessageRequest);
+  }
+
+  @Test
+  public void modifyRequestWillAddSpanInformationToMessageAttributes() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+
+    // act
+    final SendMessageRequest newRequest =
+        (SendMessageRequest) interceptor.modifyRequest(() -> request, executionAttributes);
+    final Span span = executionAttributes.getAttribute(SPAN_EXECUTION_ATTRIBUTE);
+    span.finish();
+
+    // assert
+    assertThat(newRequest.messageAttributes()).containsKeys("b3");
+    final TraceContext.Extractor<Map<String, MessageAttributeValue>> attributeExtractor =
+        tracing.propagation().extractor(new SendMessageRemoteGetter());
+    final TraceContextOrSamplingFlags traceContextOrSamplingFlags =
+        attributeExtractor.extract(newRequest.messageAttributes());
+    final MutableSpan sendMessageMutableSpan = spanHandler.get(0);
+    assertThat(traceContextOrSamplingFlags).isNotNull();
+    assertThat(traceContextOrSamplingFlags.context().traceIdString()).isEqualTo(
+        sendMessageMutableSpan.traceId());
+    assertThat(traceContextOrSamplingFlags.context().spanIdString()).isEqualTo(
+        sendMessageMutableSpan.id());
+  }
+
+  @Test
+  public void modifyRequestWhenSpanDeletedFromExecutionContextWillReturnOriginalRequest() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    executionAttributes.putAttribute(SPAN_EXECUTION_ATTRIBUTE, null);
+
+    // act
+    final SendMessageRequest newRequest =
+        (SendMessageRequest) interceptor.modifyRequest(() -> request, executionAttributes);
+
+    // assert
+    assertThat(newRequest).isSameAs(request);
+  }
+
+  @Test
+  public void afterExecutionWillFinishSpan() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionSuccess(request, "messageId");
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isNotEmpty();
+  }
+
+  @Test
+  public void afterExecutionOnSuccessWillAddResultingMessageIdToSpan() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution =
+        mockAfterExecutionSuccess(request, "returned-message-id");
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isNotEmpty();
+    assertThat(spanHandler.get(0).tag("message.id")).isEqualTo("returned-message-id");
+  }
+
+  @Test
+  public void afterExecutionOnFailureWillErrorOutTheSpan() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionFailure(request, 400);
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isNotEmpty();
+    assertThat(spanHandler.get(0).error()).hasMessage("Error placing message onto SQS queue");
+    assertThat(spanHandler.get(0).tag("response.code")).isEqualTo("400");
+  }
+
+  @Test
+  public void afterExecutionCustomSpanSuccessDecoratorWillRunAfterSuccess() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionSuccess(request, "message-id");
+    final SendMessageTracingExecutionInterceptor.SpanDecorator spanDecorator =
+        new SendMessageTracingExecutionInterceptor.SpanDecorator() {
+          @Override
+          public void decorateMessageSpanOnSuccess(SendMessageRequest request,
+              SendMessageResponse response, SdkHttpResponse sdkHttpResponse,
+              Span span) {
+            span.tag("test", "value");
+          }
+        };
+
+    // act
+    final SendMessageTracingExecutionInterceptor interceptor =
+        new SendMessageTracingExecutionInterceptor(tracing, spanDecorator);
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isNotEmpty();
+    assertThat(spanHandler.get(0).tag("test")).isEqualTo("value");
+  }
+
+  @Test
+  public void afterExecutionCustomSpanFailureDecoratorWillRunAfterFailure() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    final Context.AfterExecution afterExecution = mockAfterExecutionFailure(request, 500);
+    final SendMessageTracingExecutionInterceptor.SpanDecorator spanDecorator =
+        new SendMessageTracingExecutionInterceptor.SpanDecorator() {
+          @Override
+          public void decorateMessageSpanOnFailure(SendMessageRequest sendMessageRequest,
+              SendMessageResponse response, SdkHttpResponse sdkHttpResponse,
+              Span span) {
+            span.tag("test", "value");
+
+          }
+        };
+
+    // act
+    final SendMessageTracingExecutionInterceptor interceptor =
+        new SendMessageTracingExecutionInterceptor(tracing, spanDecorator);
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isNotEmpty();
+    assertThat(spanHandler.get(0).tag("test")).isEqualTo("value");
+    assertThat(spanHandler.get(0).error()).hasMessage("Error placing message onto SQS queue");
+  }
+
+  @Test
+  public void afterExecutionWillDoNothingIfNotSendMessageRequest() {
+    // arrange
+    final DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .receiptHandle("receiptHandle")
+        .build();
+    final Context.AfterExecution afterExecution =
+        mockAfterExecutionFailure(deleteMessageRequest, 400);
+    final Span span = tracing.tracer().nextSpan();
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    executionAttributes.putAttribute(SPAN_EXECUTION_ATTRIBUTE, span);
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isEmpty();
+  }
+
+  @Test
+  public void afterExecutionWillDoNothingIfNotSpanIsNotPresentInExecutionAttributes() {
+    // arrange
+    final SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("body")
+        .messageAttributes(new HashMap<>())
+        .build();
+    final Context.AfterExecution afterExecution = mockAfterExecutionFailure(request, 400);
+    final ExecutionAttributes executionAttributes = new ExecutionAttributes();
+    interceptor.beforeExecution(() -> request, executionAttributes);
+    executionAttributes.putAttribute(SPAN_EXECUTION_ATTRIBUTE, null);
+
+    // act
+    interceptor.afterExecution(afterExecution, executionAttributes);
+
+    // assert
+    assertThat(spanHandler.spans()).isEmpty();
+  }
+
+  private Context.AfterExecution mockAfterExecutionSuccess(final SdkRequest request,
+      final String messageId) {
+    final Context.AfterExecution afterExecution = mock(Context.AfterExecution.class);
+    final SdkHttpResponse sdkHttpResponse = mock(SdkHttpResponse.class);
+    when(afterExecution.httpResponse()).thenReturn(sdkHttpResponse);
+    when(afterExecution.request()).thenReturn(request);
+    when(sdkHttpResponse.isSuccessful()).thenReturn(true);
+    when(afterExecution.response()).thenReturn(SendMessageResponse.builder()
+        .messageId(messageId)
+        .build());
+    return afterExecution;
+  }
+
+  private Context.AfterExecution mockAfterExecutionFailure(final SdkRequest request,
+      final int statusCode) {
+    final Context.AfterExecution afterExecution = mock(Context.AfterExecution.class);
+    final SdkHttpResponse sdkHttpResponse = mock(SdkHttpResponse.class);
+    when(afterExecution.httpResponse()).thenReturn(sdkHttpResponse);
+    when(afterExecution.request()).thenReturn(request);
+    when(sdkHttpResponse.isSuccessful()).thenReturn(false);
+    when(sdkHttpResponse.statusCode()).thenReturn(statusCode);
+    return afterExecution;
+  }
+}

--- a/brave-instrumentation/pom.xml
+++ b/brave-instrumentation/pom.xml
@@ -33,6 +33,7 @@
     <module>aws-java-sdk-core</module>
     <module>aws-java-sdk-v2-core</module>
     <module>aws-java-sdk-sqs</module>
+    <module>aws-java-sdk-sqs-v2</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
As the AWS SDK changed in V2 the existing SQS brave instrumentation needed to be updated to the latest API.

This is mostly a copy of [SendMessageTracingRequestHandler](https://github.com/openzipkin/zipkin-aws/blob/master/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SendMessageTracingRequestHandler.java) but with some breaking changes between the versions:
- Spans can now error out for an individual message if the entire HTTP request failed or an individual message failed to be published in a batch.
- Spans are now not 0 seconds in length and will instead be timed for the length of time it takes to send the message to SQS. Not sure if this is a problem.
- The RemoteSetter and RemoteGetter have been pulled out to their own classes to allow for easier sharing with consumers. E.g. other SQS libraries like [java-dynamic-sqs-listener](https://github.com/JaidenAshmore/java-dynamic-sqs-listener) should be able to easily extract this brave tracing information from the headers.
- I did not provide a [SqsMessageTracing](https://github.com/openzipkin/zipkin-aws/blob/master/brave-instrumentation/aws-java-sdk-sqs/src/main/java/brave/instrumentation/aws/sqs/SqsMessageTracing.java) class as it seemed a little unnecessary. Maybe I am missing why this class would be useful? Otherwise let me know and I can create this.
- Instead of a single `ExecutionInterceptor` that handles both the single message and batch cases, I have split this into two classes to simplify testing and reduce the amount of branches that would have been present if this was merged into a single interceptor.
- The batch send message does not have an overarching span that represents this operation and will just have the span for each message being sent. I am not sure whether I felt that was necessary to include but if you disagree I am happy to put it back.
- Added integration tests so it runs against an actual SQS server. Only happy path is tested.
- Added the ability to customize the default span tagging.  I thought that consumers may want to override the tags with their own logic so I created a `SpanDecorator` that can be supplied to provide this customization.
- This module was made to be Java 8 compliant. This was more a personal preference for having Java 8 classes like `Optional`, etc. 

Looking forward to the feedback. Thanks!