### PR TITLE
Fixes on-demand build in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,10 +4,23 @@
 # Install script runs within Docker
 !build-bin/maven/maven_build
 !build-bin/maven/maven_build_or_unjar
+!build-bin/maven/maven_opts
 !build-bin/maven/maven_unjar
 
-# Allow on-demand "mvn package"
-!**/src/main/**
+# Allow on-demand "mvn package". <modules> referenced in pom.xml must be added even if not built
+!aws-junit/src/main/**
+!collector/kinesis/src/main/**
+!collector/sqs/src/main/**
+!brave/instrumentation-aws-java-sdk-core/src/main/**
+!brave/instrumentation-aws-java-sdk-v2-core/src/main/**
+!brave/instrumentation-aws-java-sdk-sqs/src/main/**
+!brave/propagation-aws/src/main/**
+!module/src/main/**
+!reporter/reporter-xray-udp/src/main/**
+!reporter/sender-awssdk-sqs/src/main/**
+!reporter/sender-kinesis/src/main/**
+!reporter/sender-sqs/src/main/**
+!storage/xray-udp/src/main/**
 !**/pom.xml
 
 # Allow re-use of built artifacts when using "mvn package"

--- a/build-bin/maven/maven_build
+++ b/build-bin/maven/maven_build
@@ -18,4 +18,4 @@ set -ue
 export MAVEN_OPTS="$($(dirname "$0")/maven_opts)"
 
 (if [ "${MAVEN_PROJECT_BASEDIR:-.}" != "." ]; then cd ${MAVEN_PROJECT_BASEDIR}; fi && \
-mvn -T1C -q --batch-mode -DskipTests package)
+mvn -T1C -q --batch-mode -DskipTests package "$@")

--- a/build-bin/maven/maven_build_or_unjar
+++ b/build-bin/maven/maven_build_or_unjar
@@ -58,5 +58,5 @@ esac
 set -ue
 
 echo "*** Building snapshot from source..."
-$(dirname "$0")/maven_build
+$(dirname "$0")/maven_build -pl :${artifact_id} --am
 $(dirname "$0")/maven_unjar $args

--- a/build-bin/maven/maven_build_or_unjar
+++ b/build-bin/maven/maven_build_or_unjar
@@ -40,7 +40,7 @@ args="${group_id} ${artifact_id} ${version} ${classifier}"
 # Fail on unset variables, but don't quit on rc!=0, so we can log what happened
 set -u +e
 
-$(dirname "$0")/maven_unjar $args
+unjar_out=$($(dirname "$0")/maven_unjar $args 2>&1)
 unjar_rc=$?
 
 if [ "${unjar_rc}" = "0" ] || [ -z "${pom:-}" ]; then
@@ -51,6 +51,7 @@ case ${version} in
   *-SNAPSHOT )
     ;;
   * )
+    >&2 echo ${unjar_out}
     exit ${unjar_rc}
     ;;
 esac

--- a/build-bin/maven/maven_release
+++ b/build-bin/maven/maven_release
@@ -40,4 +40,4 @@ if [ "$commit_local_release_branch" != "$commit_remote_release_branch" ]; then
 fi
 
 # Prepare and push release commits and the version tag (N.N.N), which triggers deployment.
-./mvnw --batch-mode -nsu -DreleaseVersion=${release_version} -Darguments=-DskipTests release:prepare
+./mvnw --batch-mode -nsu -DreleaseVersion=${release_version} -Denforcer.fail=false -Darguments="-DskipTests -Denforcer.fail=false" release:prepare

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -26,7 +26,7 @@ set -eu
 # the artifact you are looking for.
 #
 # Ex.
-# !./module/target/zipkin-module-xray-*-module.jar
+# !./module/target/zipkin-module-*-module.jar
 
 group_id=${1?group_id is required}
 artifact_id=${2?artifact_id is required}
@@ -60,7 +60,8 @@ elif [ -n "${MAVEN_PROJECT_BASEDIR:-}" ]; then
 fi
 
 if ! test -f ${artifact_id}.jar && [ ${is_release} = "true" ]; then
-  mvn_get="mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
+  mvn_get="mvn -q --batch-mode -Denforcer.fail=false \
+  org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
   -Dtransitive=false -DgroupId=${group_id} -DartifactId=${artifact_id} -Dversion=${version}"
 
   if [ -n "${classifier}" ]; then


### PR DESCRIPTION
When there was no prior build, this would have not worked

```bash
build-bin/docker/docker_build openzipkin/zipkin-aws:test
```