### PR TITLE
Fixed typo in elasticsearch module name

### DIFF
--- a/module/src/main/resources/zipkin-server-aws.yml
+++ b/module/src/main/resources/zipkin-server-aws.yml
@@ -6,7 +6,7 @@ spring:
 zipkin:
   internal:
     module:
-      elasticsearch-aws: zipkin.module.storage.aws.elasticsearchZipkinElasticsearchAwsStorageModule
+      elasticsearch-aws: zipkin.module.aws.elasticsearch.ZipkinElasticsearchAwsStorageModule
       kinesis: zipkin.module.aws.kinesis.ZipkinKinesisCollectorModule
       sqs: zipkin.module.aws.sqs.ZipkinSQSCollectorModule
       xray: zipkin.module.aws.xray.ZipkinXRayStorageModule


### PR DESCRIPTION
ZipkinModuleImporter throws the following error, most likely due to a typo (a missing dot and wrong folder) :
z.s.i.ZipkinModuleImporter               : skipping unloadable module elasticsearch-aws

java.lang.ClassNotFoundException: zipkin.module.storage.aws.elasticsearchZipkinElasticsearchAwsStorageModule