### PR TITLE
Upgrade Zipkin and Log4j

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 The OpenZipkin Authors
+# Copyright 2016-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # zipkin version should match zipkin.version in /pom.xml
-ARG zipkin_version=2.23.14
+ARG zipkin_version=2.23.15
 
 # java_version is used during the installation process to build or download the module jar.
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # zipkin version should match zipkin.version in /pom.xml
-ARG zipkin_version=2.23.2
+ARG zipkin_version=2.23.14
 
 # java_version is used during the installation process to build or download the module jar.
 #

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2021 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>2.23.14</zipkin.version>
+    <zipkin.version>2.23.15</zipkin.version>
     <zipkin-reporter.version>2.16.3</zipkin-reporter.version>
     <spring-boot.version>2.4.1</spring-boot.version>
     <jackson.version>2.12.0</jackson.version>
@@ -87,7 +87,7 @@
     <aws-java-sdk.version>1.11.926</aws-java-sdk.version>
     <sdk-core.version>2.15.53</sdk-core.version>
 
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.0</log4j.version>
     <okhttp.version>4.9.0</okhttp.version>
 
     <assertj.version>3.18.1</assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>2.23.2</zipkin.version>
+    <zipkin.version>2.23.14</zipkin.version>
     <zipkin-reporter.version>2.16.3</zipkin-reporter.version>
     <spring-boot.version>2.4.1</spring-boot.version>
     <jackson.version>2.12.0</jackson.version>
@@ -87,7 +87,7 @@
     <aws-java-sdk.version>1.11.926</aws-java-sdk.version>
     <sdk-core.version>2.15.53</sdk-core.version>
 
-    <log4j.version>2.14.0</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <okhttp.version>4.9.0</okhttp.version>
 
     <assertj.version>3.18.1</assertj.version>


### PR DESCRIPTION
This PR upgrades Zipkin to the latest version, which solves the Log4j vulnerability. It also upgrades the log4j version used for the tests