### PR TITLE
fix: enable docker buildkit

### DIFF
--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -24,4 +24,4 @@ docker_args=$($(dirname "$0")/docker_args ${version})
 #  * It only supports one platform/arch on load https://github.com/docker/buildx/issues/59
 #  * It would pull Docker Hub for moby/buildkit or multiarch/qemu-user-static images, using up quota
 echo "Building image ${docker_tag}"
-DOCKER_BUILDKIT=0 docker build --pull ${docker_args} --tag ${docker_tag} .
+DOCKER_BUILDKIT=1 docker build --pull ${docker_args} --tag ${docker_tag} .

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2016-2020 The OpenZipkin Authors
+# Copyright 2016-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -27,7 +27,9 @@ set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
 version=${2:-master}
-export DOCKER_BUILDKIT=0
+# We don't need build kit, but Docker 20.10 no longer accepts --platform without it.
+# It is simpler to just always enable it. See https://github.com/moby/moby/issues/41552
+export DOCKER_BUILDKIT=1
 
 case ${version} in
   master )

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2016-2020 The OpenZipkin Authors
+# Copyright 2016-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Solves this kind of issues:

```
Step 7/22 : COPY --from=scratch /code/ .
invalid from flag value scratch: image with reference 
sha256:b12ae8e35357a7aa30ed72e5e406a61e1c287ba96471601b43c8e066f6795fa6 was found but does not match the 
specified platform: wanted linux/arm64, actual: linux/amd64
```

Test it with:

```
build-bin/docker/docker_build openzipkin/zipkin-aws:test
```