### PR TITLE
Fixes #188, NPE when AwsInjector injects TracingContext without AmznTraceId extra

### DIFF
--- a/aws-junit/pom.xml
+++ b/aws-junit/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/brave/instrumentation-aws-java-sdk-core/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/brave/instrumentation-aws-java-sdk-sqs/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-sqs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/brave/instrumentation-aws-java-sdk-v2-core/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-v2-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/brave/propagation-aws/pom.xml
+++ b/brave/propagation-aws/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSInjector.java
+++ b/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSInjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSInjector.java
+++ b/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSInjector.java
@@ -45,7 +45,8 @@ final class AWSInjector<R> implements TraceContext.Injector<R> {
   @Override
   public void inject(TraceContext traceContext, R request) {
     AmznTraceId amznTraceId = traceContext.findExtra(AmznTraceId.class);
-    int customFieldsLength = amznTraceId.customFields.length();
+    int customFieldsLength = amznTraceId != null ? amznTraceId.customFields.length() : 0;
+
     // Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1
     char[] result = new char[74 + customFieldsLength];
     System.arraycopy(ROOT, 0, result, 0, 5);
@@ -54,12 +55,14 @@ final class AWSInjector<R> implements TraceContext.Injector<R> {
     writeHexLong(result, 48, traceContext.spanId());
     System.arraycopy(SAMPLED, 0, result, 64, 9);
     Boolean sampled = traceContext.sampled();
+
     // Sampled status is same as B3, but ? means downstream decides (like omitting X-B3-Sampled)
     // https://github.com/aws/aws-xray-sdk-go/blob/391885218b556c43ed05a1e736a766d70fc416f1/header/header.go#L50
     result[73] = sampled == null ? '?' : sampled ? '1' : '0';
     for (int i = 0; i < customFieldsLength; i++) {
       result[i + 74] = amznTraceId.customFields.charAt(i);
     }
+
     setter.put(request, AMZN_TRACE_ID_NAME, new String(result));
   }
 }

--- a/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSInjectorTest.java
+++ b/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSInjectorTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package brave.propagation.aws;
 
 import brave.propagation.Propagation;

--- a/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSInjectorTest.java
+++ b/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSInjectorTest.java
@@ -1,0 +1,89 @@
+package brave.propagation.aws;
+
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import static brave.internal.codec.HexCodec.lowerHexToUnsignedLong;
+import static brave.propagation.aws.AWSPropagation.AMZN_TRACE_ID_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class AWSInjectorTest {
+  private AWSInjector<Object> instance;
+  private Propagation.Setter<Object, String> setterMock;
+
+  // Regular trace ID and context.
+  private final static String traceId =
+      "Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1";
+  private final static TraceContext context = TraceContext.newBuilder()
+      .traceIdHigh(lowerHexToUnsignedLong("67891233abcdef01"))
+      .traceId(lowerHexToUnsignedLong("2345678912345678"))
+      .spanId(lowerHexToUnsignedLong("463ac35c9f6413ad"))
+      .sampled(true)
+      .addExtra(AWSPropagation.NO_CUSTOM_FIELDS)
+      .build();
+
+  // Trace ID and context with the customFields set.
+  private final static String traceIdCustomFields =
+      "Root=1-67891233-abcdef012345678912345678;Parent=463ac35c9f6413ad;Sampled=1;CustomField=Foo-Bar";
+  private final static TraceContext contextCustomFields = TraceContext.newBuilder()
+      .traceIdHigh(lowerHexToUnsignedLong("67891233abcdef01"))
+      .traceId(lowerHexToUnsignedLong("2345678912345678"))
+      .spanId(lowerHexToUnsignedLong("463ac35c9f6413ad"))
+      .sampled(true)
+      .addExtra(new AWSPropagation.AmznTraceId(";CustomField=Foo-Bar"))
+      .build();
+
+  // Regular context where the extras are not set.
+  private final static TraceContext contextNoExtras = TraceContext.newBuilder()
+      .traceIdHigh(lowerHexToUnsignedLong("67891233abcdef01"))
+      .traceId(lowerHexToUnsignedLong("2345678912345678"))
+      .spanId(lowerHexToUnsignedLong("463ac35c9f6413ad"))
+      .sampled(true)
+      .build();
+
+  @Before
+  public void setUp() {
+    // The setter is used to verify that the correct trace ID is generated.
+    setterMock = (Propagation.Setter<Object, String>) mock(Propagation.Setter.class);
+    // The AWSPropagator is unused, so passing null is fine for testing.
+    // It's not possible to mock using Mockito, because it's a final class and mockito-inline is not used in the project.
+    instance = new AWSInjector<>(null, setterMock);
+  }
+
+  @Test
+  public void injectTraceContext_ExpectTraceId() {
+    Object requestMock = mock(Object.class);
+
+    // When injecting a trace context.
+    instance.inject(context, requestMock);
+
+    // Expect to see the corresponding trace ID set on the request.
+    verify(setterMock, times(1)).put(requestMock, AMZN_TRACE_ID_NAME, traceId);
+  }
+
+  @Test
+  public void injectTraceContextWithCustomFields_ExpectTraceIdWithCustomFields() {
+    Object requestMock = mock(Object.class);
+
+    // When injecting a trace context with custom fields.
+    instance.inject(contextCustomFields, requestMock);
+
+    // Expect to see the corresponding trace ID set on the request.
+    verify(setterMock, times(1)).put(requestMock, AMZN_TRACE_ID_NAME, traceIdCustomFields);
+  }
+
+  @Test
+  public void injectTraceContextWithNoExtras_ExpectTraceId() {
+    Object requestMock = mock(Object.class);
+
+    // When injecting a trace context with no extras set.
+    instance.inject(contextNoExtras, requestMock);
+
+    // Expect to see the corresponding trace ID set on the request.
+    verify(setterMock, times(1)).put(requestMock, AMZN_TRACE_ID_NAME, traceId);
+  }
+}

--- a/collector/kinesis/pom.xml
+++ b/collector/kinesis/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/collector/sqs/pom.xml
+++ b/collector/sqs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/reporter/reporter-xray-udp/pom.xml
+++ b/reporter/reporter-xray-udp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/reporter/sender-awssdk-sqs/pom.xml
+++ b/reporter/sender-awssdk-sqs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/reporter/sender-kinesis/pom.xml
+++ b/reporter/sender-kinesis/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/reporter/sender-sqs/pom.xml
+++ b/reporter/sender-sqs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/storage/xray-udp/pom.xml
+++ b/storage/xray-udp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
This bug was introduced in 0.23.2 by #186 and reported in #188.
The introduced tests now pass and should help avoid regression in this area.