### PR TITLE
fix(build): set versions to proper snapshot

### DIFF
--- a/aws-junit/pom.xml
+++ b/aws-junit/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-aws-junit</artifactId>

--- a/brave/instrumentation-aws-java-sdk-core/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/instrumentation-aws-java-sdk-sqs/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/instrumentation-aws-java-sdk-v2-core/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-v2-core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/propagation-aws/pom.xml
+++ b/brave/propagation-aws/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/collector/kinesis/pom.xml
+++ b/collector/kinesis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/collector/sqs/pom.xml
+++ b/collector/sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-module-aws</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2022 The OpenZipkin Authors
+    Copyright 2016-2023 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.aws</groupId>
   <artifactId>zipkin-aws-parent</artifactId>
-  <version>0.23.4</version>
+  <version>0.23.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/reporter/reporter-xray-udp/pom.xml
+++ b/reporter/reporter-xray-udp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-awssdk-sqs/pom.xml
+++ b/reporter/sender-awssdk-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-kinesis/pom.xml
+++ b/reporter/sender-kinesis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-sqs/pom.xml
+++ b/reporter/sender-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/storage/xray-udp/pom.xml
+++ b/storage/xray-udp/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.23.4</version>
+    <version>0.23.5-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Seems that in the last release the version didn't turn back into `-SNAPSHOT`. 