### PR TITLE
refs #201: java.lang.IllegalStateException: Missing: traceId with AWS propagation type within AWSExtractor 

### DIFF
--- a/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSExtractor.java
+++ b/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSExtractor.java
@@ -124,6 +124,7 @@ final class AWSExtractor<R> implements Extractor<R> {
             } else if (c >= 'a' && c <= 'f') {
               traceIdHigh |= c - 'a' + 10;
             } else {
+              traceIdHigh = 0L;
               break OUTER; // invalid format
             }
           }
@@ -136,6 +137,8 @@ final class AWSExtractor<R> implements Extractor<R> {
             } else if (c >= 'a' && c <= 'f') {
               traceId |= c - 'a' + 10;
             } else {
+              traceIdHigh = 0L;
+              traceId = 0L;
               break OUTER; // invalid format
             }
           }

--- a/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
+++ b/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
@@ -296,4 +296,15 @@ public class AWSPropagationTest {
 
     assertThat(extractor.extract(carrier).samplingFlags()).isEqualTo(SamplingFlags.EMPTY);
   }
+
+  @Test
+  public void extract_malformed_throws_exception() {
+    carrier.put("x-amzn-trace-id", "Root=1-1373cbb-77f4b48ed7ff3eebbd62b5e01;Parent=1a4e96536a3ff131;Sampled=0");
+    /*
+    This malformed trace id (timestamp with 7 characters) breaks this test:
+    Expected behaviour -> empty string
+    Actual behaviour -> throws java.lang.IllegalStateException: Missing: traceId
+     */
+    assertThat(extractor.extract(carrier).samplingFlags()).isEqualTo(SamplingFlags.EMPTY);
+  }
 }

--- a/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
+++ b/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
@@ -298,13 +298,16 @@ public class AWSPropagationTest {
   }
 
   @Test
-  public void extract_malformed_throws_exception() {
+  public void extract_malformed_check_not_throws_exception_different_length() {
     carrier.put("x-amzn-trace-id", "Root=1-1373cbb-77f4b48ed7ff3eebbd62b5e01;Parent=1a4e96536a3ff131;Sampled=0");
-    /*
-    This malformed trace id (timestamp with 7 characters) breaks this test:
-    Expected behaviour -> empty string
-    Actual behaviour -> throws java.lang.IllegalStateException: Missing: traceId
-     */
+
+    assertThat(extractor.extract(carrier).samplingFlags()).isEqualTo(SamplingFlags.EMPTY);
+  }
+
+  @Test
+  public void extract_malformed_throws_exception_not_hexadecimal_value() {
+    carrier.put("x-amzn-trace-id", "Root=1-1z373cbb-77f4b48ed7ff3eebbd62b5e01;Parent=1a4e96536a3ff131;Sampled=0");
+
     assertThat(extractor.extract(carrier).samplingFlags()).isEqualTo(SamplingFlags.EMPTY);
   }
 }


### PR DESCRIPTION
In this **PR** we want to propose a possible solution for [this issue](https://github.com/openzipkin/zipkin-aws/issues/201).

- In the first commit, the introduced test fails with the provided input: `Root=1-1373cbb-77f4b48ed7ff3eebbd62b5e01;Parent=1a4e96536a3ff131;Sampled=0` because it has a timestamp with 7 characters instead of 8. 
- In the second commit a possible solution is provided and the introduced test won't fail anymore.

We understood that the problem was that `traceIdHigh` and `traceId` variables were not reset when an unexpected condition is encountered during the parsing of the traced id. This behaviour is fixed in these lines: 
- [127](https://github.com/openzipkin/zipkin-aws/pull/203/files#diff-4cae479ac35f48f8eee3577fce4babc8d51a1e7c9b98f464b0c58c0cd803428bR127)
- [140-141](https://github.com/openzipkin/zipkin-aws/pull/203/files#diff-4cae479ac35f48f8eee3577fce4babc8d51a1e7c9b98f464b0c58c0cd803428bR140-R141)