### PR TITLE
Prepares for release by updating to Brave 5.18

### DIFF
--- a/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSPropagation.java
+++ b/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSPropagation.java
@@ -91,6 +91,8 @@ public final class AWSPropagation implements Propagation<String> {
      * @deprecated end users and instrumentation should never call this, and instead use
      * {@link #get()}. This only remains to avoid rev-lock upgrading to Brave 6.
      */
+    // This only exists for spring-cloud-sleuth, which is no longer being released. It hasn't and
+    // might not upgrade to Brave 5.18 which implements the same way.
     @Deprecated public <K> Propagation<K> create(KeyFactory<K> unused) {
       throw new UnsupportedOperationException("As of Brave 5.12, call PropagationFactory.get()");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -518,8 +518,6 @@
             <version>${maven-compiler-plugin.version}</version>
             <inherited>true</inherited>
             <configuration>
-              <source>${main.java.version}</source>
-              <target>${main.java.version}</target>
               <fork>true</fork>
               <showWarnings>true</showWarnings>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -61,17 +61,27 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <main.basedir>${project.basedir}</main.basedir>
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
 
-    <!-- groupId overrinds allow testing feature branches with jitpack -->
+    <!-- default bytecode version for src/main -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- We don't use animal-sniffer anymore as release obviates it.
+         See https://github.com/mojohaus/animal-sniffer/issues/62 -->
+    <maven.compiler.release>8</maven.compiler.release>
+
+    <!-- Tests use the floor Java version (used in release) -->
+    <maven.compiler.testSource>11</maven.compiler.testSource>
+    <maven.compiler.testTarget>11</maven.compiler.testTarget>
+    <maven.compiler.testRelease>11</maven.compiler.testRelease>
+
+    <!-- groupId overrides allow testing feature branches with jitpack -->
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
     <zipkin.version>2.27.0</zipkin.version>
     <zipkin-reporter.version>2.17.2</zipkin-reporter.version>
     <spring-boot.version>2.7.18</spring-boot.version>
-    <jackson.version>2.16.0</jackson.version>
+    <jackson.version>2.16.1</jackson.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>1.26.4</armeria.version>
@@ -82,12 +92,12 @@
     <!--    <brave.groupId>com.github.openzipkin.brave</brave.groupId>-->
     <!--    <brave.version>master-SNAPSHOT</brave.version>-->
     <brave.groupId>io.zipkin.brave</brave.groupId>
-    <brave.version>5.17.1</brave.version>
+    <brave.version>5.18.1</brave.version>
 
-    <aws-java-sdk.version>1.12.620</aws-java-sdk.version>
-    <sdk-core.version>2.22.0</sdk-core.version>
+    <aws-java-sdk.version>1.12.633</aws-java-sdk.version>
+    <sdk-core.version>2.22.13</sdk-core.version>
 
-    <log4j.version>2.22.0</log4j.version>
+    <log4j.version>2.22.1</log4j.version>
     <okhttp.version>4.12.0</okhttp.version>
 
     <assertj.version>3.25.1</assertj.version>
@@ -97,16 +107,19 @@
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.23.0</errorprone.version>
+    <errorprone.version>2.24.1</errorprone.version>
     <auto-value.version>1.10.4</auto-value.version>
 
     <license.skip>${skipTests}</license.skip>
 
-    <animal-sniffer-maven-plugin.version>1.23</animal-sniffer-maven-plugin.version>
+    <maven-surefire-plugin.argLine />
+    <maven-failsafe-plugin.argLine />
+
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.3</license-maven-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
@@ -114,12 +127,12 @@
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-help-plugin.version>3.4.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
-    <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
   </properties>
 
@@ -243,13 +256,6 @@
             <!-- Add dependencies indirectly referenced by build plugins -->
             <dynamicDependencies>
               <DynamicDependency>
-                <groupId>org.codehaus.mojo.signature</groupId>
-                <artifactId>${main.signature.artifact}</artifactId>
-                <version>1.0</version>
-                <type>signature</type>
-                <repositoryType>MAIN</repositoryType>
-              </DynamicDependency>
-              <DynamicDependency>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin-git</artifactId>
                 <version>${license-maven-plugin.version}</version>
@@ -328,10 +334,7 @@
         <version>${maven-compiler-plugin.version}</version>
         <inherited>true</inherited>
         <configuration>
-          <source>${main.java.version}</source>
-          <target>${main.java.version}</target>
           <fork>true</fork>
-          <release>8</release>
           <showWarnings>true</showWarnings>
         </configuration>
       </plugin>
@@ -387,29 +390,6 @@
           <!-- Ensure scope leak cause ends up in the console -->
           <trimStackTrace>false</trimStackTrace>
         </configuration>
-      </plugin>
-
-      <!-- Ensure no Java 9+ api usage -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>${animal-sniffer-maven-plugin.version}</version>
-        <configuration>
-          <checkTestClasses>false</checkTestClasses>
-          <skip>${skipTests}</skip>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>${main.signature.artifact}</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -574,7 +554,7 @@
                       <artifactId>error_prone_core</artifactId>
                       <version>${errorprone.version}</version>
                     </processorPath>
-                    <!-- auto-value is placed here eventhough not needed for all projects as
+                    <!-- auto-value is placed here even though not needed for all projects as
                          configuring along with errorprone is tricky in subprojects -->
                     <processorPath>
                       <groupId>com.google.auto.value</groupId>


### PR DESCRIPTION
Note after we release, we should bump major when updating to zipkin-reporter 3.0.1