### PR TITLE
deps: updates to Brave 6 and Zipkin Reporter 3

### DIFF
--- a/aws-junit/pom.xml
+++ b/aws-junit/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-aws-junit</artifactId>

--- a/brave/instrumentation-aws-java-sdk-core/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/instrumentation-aws-java-sdk-core/src/test/java/brave/instrumentation/aws/ITTracingRequestHandler.java
+++ b/brave/instrumentation-aws-java-sdk-core/src/test/java/brave/instrumentation/aws/ITTracingRequestHandler.java
@@ -14,10 +14,7 @@
 package brave.instrumentation.aws;
 
 import brave.Span;
-import brave.SpanCustomizer;
 import brave.handler.MutableSpan;
-import brave.http.HttpAdapter;
-import brave.http.HttpClientParser;
 import brave.http.HttpResponseParser;
 import brave.http.HttpTags;
 import brave.test.http.ITHttpClient;
@@ -109,52 +106,6 @@ public class ITTracingRequestHandler extends ITHttpClient<AmazonDynamoDB> {
 
     assertThat(span.tags())
         .containsEntry("http.url", url(uri))
-        .containsEntry("request_customizer.is_span", "false")
-        .containsEntry("response_customizer.is_span", "false");
-
-    testSpanHandler.takeLocalSpan();
-  }
-
-  /** Service and span names don't conform to expectations. */
-  @Override
-  @Deprecated @Test public void supportsDeprecatedPortableCustomization() {
-    String uri = "/"; // This test doesn't currently allow non-root HTTP paths
-
-    closeClient(client);
-    httpTracing = httpTracing.toBuilder()
-        .clientParser(new HttpClientParser() {
-          @Override
-          public <Req> void request(HttpAdapter<Req, ?> adapter, Req req,
-              SpanCustomizer customizer) {
-            customizer.name(adapter.method(req).toLowerCase() + " " + adapter.path(req));
-            customizer.tag("http.url", adapter.url(req)); // just the path is tagged by default
-            customizer.tag("context.visible", String.valueOf(currentTraceContext.get() != null));
-            customizer.tag("request_customizer.is_span", (customizer instanceof brave.Span) + "");
-          }
-
-          @Override
-          public <Resp> void response(HttpAdapter<?, Resp> adapter, Resp res, Throwable error,
-              SpanCustomizer customizer) {
-            super.response(adapter, res, error, customizer);
-            customizer.tag("response_customizer.is_span", (customizer instanceof brave.Span) + "");
-          }
-        })
-        .build().clientOf("remote-service");
-
-    client = newClient(server.getPort());
-    server.enqueue(new MockResponse());
-    get(client, uri);
-
-    MutableSpan span = testSpanHandler.takeRemoteSpan(Span.Kind.CLIENT);
-    assertThat(span.name())
-        .isEqualTo("GetItem"); // Overwrites default span name
-
-    assertThat(span.remoteServiceName())
-        .isEqualTo("AmazonDynamoDBv2"); // Ignores HttpTracing.serverName()
-
-    assertThat(span.tags())
-        .containsEntry("http.url", url(uri))
-        .containsEntry("context.visible", "true")
         .containsEntry("request_customizer.is_span", "false")
         .containsEntry("response_customizer.is_span", "false");
 

--- a/brave/instrumentation-aws-java-sdk-sqs/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/instrumentation-aws-java-sdk-v2-core/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-v2-core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/instrumentation-aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/AwsSdkTracing.java
+++ b/brave/instrumentation-aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/AwsSdkTracing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,13 +14,13 @@
 package brave.instrumentation.awsv2;
 
 import brave.http.HttpTracing;
+import brave.internal.Nullable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
-import zipkin2.internal.Nullable;
 
 public final class AwsSdkTracing {
   public static AwsSdkTracing create(HttpTracing httpTracing) {

--- a/brave/instrumentation-aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
+++ b/brave/instrumentation-aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
 import brave.instrumentation.awsv2.AwsSdkTracing.HttpClientRequest;
 import brave.instrumentation.awsv2.AwsSdkTracing.HttpClientResponse;
+import brave.internal.Nullable;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
@@ -26,7 +27,6 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpRequest;
-import zipkin2.internal.Nullable;
 
 /**
  * Traces AWS Java SDK V2 calls. Adds on the standard zipkin/brave http tags, as well as tags that

--- a/brave/propagation-aws/pom.xml
+++ b/brave/propagation-aws/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSPropagation.java
+++ b/brave/propagation-aws/src/main/java/brave/propagation/aws/AWSPropagation.java
@@ -16,7 +16,6 @@ package brave.propagation.aws;
 import brave.Tracing;
 import brave.baggage.BaggageField;
 import brave.internal.Nullable;
-import brave.internal.propagation.StringPropagationAdapter;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContext.Extractor;
@@ -70,11 +69,7 @@ public final class AWSPropagation implements Propagation<String> {
   /** When present, this context was created with AWSPropagation */
   static final AmznTraceId NO_CUSTOM_FIELDS = new AmznTraceId("");
   static final Extractor<String> STRING_EXTRACTOR =
-      INSTANCE.extractor(new Getter<String, String>() {
-        @Override public String get(String request, String key) {
-          return request;
-        }
-      });
+      INSTANCE.extractor((request, key) -> request);
   public static final Propagation.Factory FACTORY = new Factory();
 
   static final char[] ROOT = "Root=".toCharArray();
@@ -85,16 +80,6 @@ public final class AWSPropagation implements Propagation<String> {
   static final class Factory extends Propagation.Factory {
     @Override public Propagation<String> get() {
       return INSTANCE;
-    }
-
-    /**
-     * @deprecated end users and instrumentation should never call this, and instead use
-     * {@link #get()}. This only remains to avoid rev-lock upgrading to Brave 6.
-     */
-    // This only exists for spring-cloud-sleuth, which is no longer being released. It hasn't and
-    // might not upgrade to Brave 5.18 which implements the same way.
-    @Deprecated public <K> Propagation<K> create(KeyFactory<K> unused) {
-      throw new UnsupportedOperationException("As of Brave 5.12, call PropagationFactory.get()");
     }
 
     @Override public boolean supportsJoin() {

--- a/collector/kinesis/pom.xml
+++ b/collector/kinesis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/collector/sqs/pom.xml
+++ b/collector/sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-module-aws</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.aws</groupId>
   <artifactId>zipkin-aws-parent</artifactId>
-  <version>0.24.1-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -78,8 +78,8 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>2.27.0</zipkin.version>
-    <zipkin-reporter.version>2.17.2</zipkin-reporter.version>
+    <zipkin.version>2.27.1</zipkin.version>
+    <zipkin-reporter.version>3.0.2</zipkin-reporter.version>
     <spring-boot.version>2.7.18</spring-boot.version>
     <jackson.version>2.16.1</jackson.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->
@@ -92,7 +92,7 @@
     <!--    <brave.groupId>com.github.openzipkin.brave</brave.groupId>-->
     <!--    <brave.version>master-SNAPSHOT</brave.version>-->
     <brave.groupId>io.zipkin.brave</brave.groupId>
-    <brave.version>5.18.1</brave.version>
+    <brave.version>6.0.0</brave.version>
 
     <aws-java-sdk.version>1.12.633</aws-java-sdk.version>
     <sdk-core.version>2.22.13</sdk-core.version>

--- a/reporter/reporter-xray-udp/pom.xml
+++ b/reporter/reporter-xray-udp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-awssdk-sqs/pom.xml
+++ b/reporter/sender-awssdk-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-awssdk-sqs/src/main/java/zipkin2/reporter/awssdk/sqs/AbstractSender.java
+++ b/reporter/sender-awssdk-sqs/src/main/java/zipkin2/reporter/awssdk/sqs/AbstractSender.java
@@ -17,9 +17,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
-import zipkin2.Call;
-import zipkin2.codec.Encoding;
 import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Encoding;
 import zipkin2.reporter.Sender;
 
 abstract class AbstractSender extends Sender {
@@ -74,5 +74,4 @@ abstract class AbstractSender extends Sender {
     int listSize = encoding.listSizeInBytes(list);
     return (listSize + 2) * 4 / 3; // account for base64 encoding
   }
-
 }

--- a/reporter/sender-awssdk-sqs/src/main/java/zipkin2/reporter/awssdk/sqs/SQSAsyncSender.java
+++ b/reporter/sender-awssdk-sqs/src/main/java/zipkin2/reporter/awssdk/sqs/SQSAsyncSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,9 +17,9 @@ import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.codec.Encoding;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.Encoding;
 
 public final class SQSAsyncSender extends AbstractSender {
 

--- a/reporter/sender-awssdk-sqs/src/main/java/zipkin2/reporter/awssdk/sqs/SQSSender.java
+++ b/reporter/sender-awssdk-sqs/src/main/java/zipkin2/reporter/awssdk/sqs/SQSSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,9 +15,9 @@ package zipkin2.reporter.awssdk.sqs;
 
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.codec.Encoding;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.Encoding;
 
 public final class SQSSender extends AbstractSender {
 

--- a/reporter/sender-awssdk-sqs/src/test/java/zipkin2/reporter/awssdk/sqs/SQSAsyncSenderTest.java
+++ b/reporter/sender-awssdk-sqs/src/test/java/zipkin2/reporter/awssdk/sqs/SQSAsyncSenderTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -27,13 +26,13 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.CheckResult;
 import zipkin2.Span;
-import zipkin2.codec.Encoding;
-import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.junit.aws.AmazonSQSExtension;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.SpanBytesEncoder;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reporter/sender-awssdk-sqs/src/test/java/zipkin2/reporter/awssdk/sqs/SQSSenderTest.java
+++ b/reporter/sender-awssdk-sqs/src/test/java/zipkin2/reporter/awssdk/sqs/SQSSenderTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -27,13 +26,13 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.CheckResult;
 import zipkin2.Span;
-import zipkin2.codec.Encoding;
-import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.junit.aws.AmazonSQSExtension;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.SpanBytesEncoder;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reporter/sender-kinesis/pom.xml
+++ b/reporter/sender-kinesis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-kinesis/src/main/java/zipkin2/reporter/kinesis/KinesisSender.java
+++ b/reporter/sender-kinesis/src/main/java/zipkin2/reporter/kinesis/KinesisSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,13 +27,13 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.CheckResult;
-import zipkin2.codec.Encoding;
-import zipkin2.internal.Nullable;
 import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.Encoding;
 import zipkin2.reporter.Sender;
+import zipkin2.reporter.internal.Nullable;
 
 public final class KinesisSender extends Sender {
 

--- a/reporter/sender-kinesis/src/test/java/zipkin2/reporter/kinesis/KinesisSenderTest.java
+++ b/reporter/sender-kinesis/src/test/java/zipkin2/reporter/kinesis/KinesisSenderTest.java
@@ -33,13 +33,13 @@ import okio.Buffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.CheckResult;
 import zipkin2.Span;
-import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesDecoder;
-import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.SpanBytesEncoder;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reporter/sender-sqs/pom.xml
+++ b/reporter/sender-sqs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-sqs/src/main/java/zipkin2/reporter/sqs/SQSSender.java
+++ b/reporter/sender-sqs/src/main/java/zipkin2/reporter/sqs/SQSSender.java
@@ -24,14 +24,14 @@ import com.amazonaws.util.Base64;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.Future;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.CheckResult;
-import zipkin2.codec.Encoding;
-import zipkin2.internal.Nullable;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.Encoding;
 import zipkin2.reporter.Sender;
+import zipkin2.reporter.internal.Nullable;
 
 /**
  * Zipkin Sender implementation that sends spans to an SQS queue.

--- a/reporter/sender-sqs/src/test/java/zipkin2/reporter/sqs/SQSSenderTest.java
+++ b/reporter/sender-sqs/src/test/java/zipkin2/reporter/sqs/SQSSenderTest.java
@@ -20,17 +20,16 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import zipkin2.Call;
-import zipkin2.Callback;
-import zipkin2.CheckResult;
 import zipkin2.Span;
-import zipkin2.codec.Encoding;
-import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.junit.aws.AmazonSQSExtension;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.SpanBytesEncoder;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/storage/xray-udp/pom.xml
+++ b/storage/xray-udp/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Brave no longer has dependencies on zipkin types. To fully remove this dependency requires Zipkin Reporter 3 which repackages a few base types.

Call sites don't require changes, except dependency alignment. However, this sets to the next major version as it is a change.