### PR TITLE
Updates to Zipkin 3, Spring Boot 3 and JRE 17

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -24,13 +24,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
+          java-version: '17'  # earliest LTS and last that can compile the 1.6 release profile.
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-11-maven-
       - name: Create Release
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-jdk-11-maven-
+          restore-keys: ${{ runner.os }}-jdk-17-maven-
       - name: Create Release
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-11-maven-
       - name: Create Release
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
+          java-version: '17'  # earliest LTS supported by Spring Boot 3
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-17-maven-
       # Don't attempt to cache Docker. Sensitive information can be stolen
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
+          java-version: '17'  # earliest LTS supported by Spring Boot 3
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-jdk-11-maven-
+          key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-17-maven-
       - name: Build JavaDoc
         run: ./mvnw clean javadoc:aggregate -Prelease
 
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are operating system specific
       matrix:  # use latest available versions and be consistent on all workflows!
         include:
-          - java_version: 11  # Last that can compile zipkin core to 1.6 for zipkin-reporter
+          - java_version: 17  # earliest LTS supported by Spring Boot 3
             maven_args: -Prelease -Dgpg.skip -Dmaven.javadoc.skip=true
           - java_version: 21  # Most recent LTS
     steps:
@@ -69,4 +69,4 @@ jobs:
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test
-        run: build-bin/configure_test && build-bin/test
+        run: build-bin/configure_test && build-bin/test ${{ matrix.maven_args }}

--- a/aws-junit/pom.xml
+++ b/aws-junit/pom.xml
@@ -29,6 +29,11 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+
+    <!-- Only used in this repo's tests, which use floor JDK 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/brave/instrumentation-aws-java-sdk-core/src/test/java/brave/instrumentation/aws/AwsClientTracingTest.java
+++ b/brave/instrumentation-aws-java-sdk-core/src/test/java/brave/instrumentation/aws/AwsClientTracingTest.java
@@ -45,7 +45,7 @@ class AwsClientTracingTest extends ITRemote {
   public MockWebServer mockServer = new MockWebServer();
 
   @SystemStub
-  private EnvironmentVariables variables = new EnvironmentVariables();
+  private final EnvironmentVariables variables = new EnvironmentVariables();
   private AmazonDynamoDB dbClient;
   private AmazonS3 s3Client;
 
@@ -68,7 +68,7 @@ class AwsClientTracingTest extends ITRemote {
         .enableForceGlobalBucketAccess());
   }
 
-  @Test void testSpanCreatedAndTagsApplied() throws InterruptedException {
+  @Test void testSpanCreatedAndTagsApplied() {
     mockServer.enqueue(createDeleteItemResponse());
 
     dbClient.deleteItem("test", Collections.singletonMap("key", new AttributeValue("value")));
@@ -89,7 +89,7 @@ class AwsClientTracingTest extends ITRemote {
     AwsClientTracing.create(httpTracing).build(AmazonDynamoDBAsyncClientBuilder.standard());
   }
 
-  @Test void testInternalAwsRequestsDoNotThrowNPE() throws InterruptedException {
+  @Test void testInternalAwsRequestsDoNotThrowNPE() {
     // Responds to the internal HEAD request
     mockServer.enqueue(new MockResponse()
         .setResponseCode(400)
@@ -125,22 +125,23 @@ class AwsClientTracingTest extends ITRemote {
   }
 
   private MockResponse getExistsResponse() {
-    return new MockResponse().setBody("<AccessControlPolicy>\n"
-        + "  <Owner>\n"
-        + "    <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>\n"
-        + "    <DisplayName>CustomersName@amazon.com</DisplayName>\n"
-        + "  </Owner>\n"
-        + "  <AccessControlList>\n"
-        + "    <Grant>\n"
-        + "      <Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-        + "\t\t\txsi:type=\"CanonicalUser\">\n"
-        + "        <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>\n"
-        + "        <DisplayName>CustomersName@amazon.com</DisplayName>\n"
-        + "      </Grantee>\n"
-        + "      <Permission>FULL_CONTROL</Permission>\n"
-        + "    </Grant>\n"
-        + "  </AccessControlList>\n"
-        + "</AccessControlPolicy> ")
+    return new MockResponse().setBody("""
+        <AccessControlPolicy>
+          <Owner>
+            <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+            <DisplayName>CustomersName@amazon.com</DisplayName>
+          </Owner>
+          <AccessControlList>
+            <Grant>
+              <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        			xsi:type="CanonicalUser">
+                <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+                <DisplayName>CustomersName@amazon.com</DisplayName>
+              </Grantee>
+              <Permission>FULL_CONTROL</Permission>
+            </Grant>
+          </AccessControlList>
+        </AccessControlPolicy>""")
         .setResponseCode(200)
         .addHeader("x-amz-request-id", "abcd");
   }

--- a/brave/instrumentation-aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
+++ b/brave/instrumentation-aws-java-sdk-v2-core/src/main/java/brave/instrumentation/awsv2/TracingExecutionInterceptor.java
@@ -31,13 +31,13 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 /**
  * Traces AWS Java SDK V2 calls. Adds on the standard zipkin/brave http tags, as well as tags that
  * align with the XRay data model.
- *
+ * <p>
  * This implementation creates 2 types of spans to allow for better error visibility.
- *
+ * <p>
  * The outer span, "Application Span", wraps the whole SDK operation. This span uses the AWS service
  * as it's name and will NOT have a remoteService configuration, making it a local span. If the
  * entire operation results in an error then this span will have an error tag with the cause.
- *
+ * <p>
  * The inner span, "Client Span", is created for each outgoing HTTP request. This span will be of
  * type CLIENT. The remoteService will be the name of the AWS service, and the span name will be the
  * name of the operation being done. If the request results in an error then the span will be tagged

--- a/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
+++ b/brave/propagation-aws/src/test/java/brave/propagation/aws/AWSPropagationTest.java
@@ -55,9 +55,11 @@ class AWSPropagationTest {
   @Test void traceIdWhenPassThrough() {
     carrier.put(
         "x-amzn-trace-id",
-        "Robot=Hello;Self=1-582113d1-1e48b74b3603af8479078ed6;  "
-            + "Root=1-58211399-36d228ad5d99923122bbe354;  "
-            + "TotalTimeSoFar=112ms;CalledFrom=Foo");
+        """
+        Robot=Hello;Self=1-582113d1-1e48b74b3603af8479078ed6;  \
+        Root=1-58211399-36d228ad5d99923122bbe354;  \
+        TotalTimeSoFar=112ms;CalledFrom=Foo\
+        """);
 
     TraceContext context = contextWithPassThrough();
 
@@ -186,9 +188,11 @@ class AWSPropagationTest {
     // we currently permit them
     carrier.put(
         "x-amzn-trace-id",
-        "Robot=Hello;Self=1-582113d1-1e48b74b3603af8479078ed6;  "
-            + "Root=1-58211399-36d228ad5d99923122bbe354;  "
-            + "TotalTimeSoFar=112ms;CalledFrom=Foo");
+        """
+        Robot=Hello;Self=1-582113d1-1e48b74b3603af8479078ed6;  \
+        Root=1-58211399-36d228ad5d99923122bbe354;  \
+        TotalTimeSoFar=112ms;CalledFrom=Foo\
+        """);
 
     TraceContextOrSamplingFlags extracted = extractor.extract(carrier);
     assertThat(extracted.traceIdContext())

--- a/collector/kinesis/pom.xml
+++ b/collector/kinesis/pom.xml
@@ -29,6 +29,11 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <!-- Only used in zipkin-server, which has floor JRE 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/collector/kinesis/src/main/java/zipkin2/collector/kinesis/KinesisCollector.java
+++ b/collector/kinesis/src/main/java/zipkin2/collector/kinesis/KinesisCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -103,9 +103,8 @@ public final class KinesisCollector extends CollectorComponent {
 
   private final Executor executor;
   private Worker worker;
-  private IRecordProcessorFactory processor;
 
-  KinesisCollector(Builder builder) {
+    KinesisCollector(Builder builder) {
     this.collector = builder.delegate.build();
     this.metrics = builder.metrics;
     this.appName = builder.appName;
@@ -133,7 +132,7 @@ public final class KinesisCollector extends CollectorComponent {
         new KinesisClientLibConfiguration(appName, streamName, credentialsProvider, workerId);
     config.withRegionName(regionName);
 
-    processor = new KinesisRecordProcessorFactory(collector, metrics);
+      IRecordProcessorFactory processor = new KinesisRecordProcessorFactory(collector, metrics);
     worker = new Worker.Builder().recordProcessorFactory(processor).config(config).build();
 
     executor.execute(worker);

--- a/collector/kinesis/src/main/java/zipkin2/collector/kinesis/KinesisSpanProcessor.java
+++ b/collector/kinesis/src/main/java/zipkin2/collector/kinesis/KinesisSpanProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,14 +23,15 @@ import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorMetrics;
 
 final class KinesisSpanProcessor implements IRecordProcessor {
-  static final Callback<Void> NOOP =
-      new Callback<Void>() {
-        @Override
-        public void onSuccess(Void value) {}
+  static final Callback<Void> NOOP = new Callback<>() {
+    @Override
+    public void onSuccess(Void value) {
+    }
 
-        @Override
-        public void onError(Throwable t) {}
-      };
+    @Override
+    public void onError(Throwable t) {
+    }
+  };
 
   final Collector collector;
   final CollectorMetrics metrics;
@@ -41,7 +42,8 @@ final class KinesisSpanProcessor implements IRecordProcessor {
   }
 
   @Override
-  public void initialize(InitializationInput initializationInput) {}
+  public void initialize(InitializationInput initializationInput) {
+  }
 
   @Override
   public void processRecords(ProcessRecordsInput processRecordsInput) {
@@ -54,5 +56,6 @@ final class KinesisSpanProcessor implements IRecordProcessor {
   }
 
   @Override
-  public void shutdown(ShutdownInput shutdownInput) {}
+  public void shutdown(ShutdownInput shutdownInput) {
+  }
 }

--- a/collector/kinesis/src/test/java/zipkin2/collector/kinesis/KinesisSpanProcessorTest.java
+++ b/collector/kinesis/src/test/java/zipkin2/collector/kinesis/KinesisSpanProcessorTest.java
@@ -40,7 +40,7 @@ class KinesisSpanProcessorTest {
           TestObjects.LOTS_OF_SPANS[0], TestObjects.LOTS_OF_SPANS[1], TestObjects.LOTS_OF_SPANS[2]);
 
   private InMemoryStorage storage;
-  private InMemoryCollectorMetrics metrics = new InMemoryCollectorMetrics();
+  private final InMemoryCollectorMetrics metrics = new InMemoryCollectorMetrics();
 
   private Collector collector;
   private KinesisSpanProcessor kinesisSpanProcessor;
@@ -80,7 +80,7 @@ class KinesisSpanProcessorTest {
   void messageWithMultipleSpans(SpanBytesEncoder encoder) {
     byte[] message = encoder.encodeList(spans);
 
-    List<Record> records = Arrays.asList(new Record().withData(ByteBuffer.wrap(message)));
+    List<Record> records = Collections.singletonList(new Record().withData(ByteBuffer.wrap(message)));
     kinesisSpanProcessor.processRecords(new ProcessRecordsInput().withRecords(records));
 
     assertThat(storage.spanStore().getTraces().size()).isEqualTo(spans.size());

--- a/collector/sqs/pom.xml
+++ b/collector/sqs/pom.xml
@@ -29,6 +29,11 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <!-- Only used in zipkin-server, which has floor JRE 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # zipkin version should match zipkin.version in /pom.xml
-ARG zipkin_version=2.27.0
+ARG zipkin_version=3.0.0
 
 # java_version is used during the installation process to build or download the module jar.
 #

--- a/module/README.md
+++ b/module/README.md
@@ -25,7 +25,7 @@ $ curl -sSL https://zipkin.io/quickstart.sh | bash -s
 $ curl -sSL https://zipkin.io/quickstart.sh | bash -s io.zipkin.aws:zipkin-module-aws:LATEST:module sqs.jar
 $ SQS_QUEUE_URL=https://ap-southeast-1.queue.amazonaws.com/012345678901/zipkin \
   java -Dloader.path='aws.jar,aws.jar!/lib' -Dspring.profiles.active=aws \
-       -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher
+       -cp zipkin.jar org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 *Note:* By default, this module will search for credentials in the $HOME/.aws directory.
@@ -70,7 +70,7 @@ Example usage:
 ```bash
 $ KINESIS_STREAM_NAME=zipkin \
   java -Dloader.path='aws.jar,aws.jar!/lib' -Dspring.profiles.active=aws \
-    -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher
+    -cp zipkin.jar org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 #### Security
@@ -148,7 +148,7 @@ Example usage:
 ```bash
 $ SQS_QUEUE_URL=https://ap-southeast-1.queue.amazonaws.com/012345678901/zipkin \
   java -Dloader.path='aws.jar,aws.jar!/lib' -Dspring.profiles.active=aws \
-    -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher
+    -cp zipkin.jar org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 #### Security
@@ -215,14 +215,14 @@ Example usage:
 ```bash
 $ STORAGE_TYPE=elasticsearch ES_HOSTS=https://search-mydomain-2rlih66ibw43ftlk4342ceeewu.ap-southeast-1.es.amazonaws.com \
   java -Dloader.path='aws.jar,aws.jar!/lib' -Dspring.profiles.active=aws \
-    -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher
+    -cp zipkin.jar org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 Alternatively, you can have zipkin implicitly lookup your domain's URL:
 ```bash
 $ STORAGE_TYPE=elasticsearch ES_AWS_DOMAIN=mydomain ES_AWS_REGION=ap-southeast-1 \
   java -Dloader.path='aws.jar,aws.jar!/lib' -Dspring.profiles.active=aws \
-    -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher
+    -cp zipkin.jar org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 #### Security
@@ -258,7 +258,7 @@ Example usage:
 
 ```bash
 $ STORAGE_TYPE=xray java -Dloader.path='aws.jar,aws.jar!/lib' -Dspring.profiles.active=aws \
-    -cp zipkin.jar org.springframework.boot.loader.PropertiesLauncher
+    -cp zipkin.jar org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 #### Experimental

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -28,6 +28,11 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+
+    <!-- Only used in zipkin-server, which has floor JRE 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencyManagement>
@@ -51,6 +56,11 @@
       <artifactId>spring-boot-autoconfigure</artifactId>
       <version>${spring-boot.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <dependency>
@@ -129,7 +139,7 @@
           <classifier>module</classifier>
           <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
           <excludeGroupIds>
-            ${zipkin.groupId},org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,com.google.code.gson,org.reactivestreams,com.google.code.findbugs,javax.annotation,org.slf4j,io.netty,io.micrometer,org.hdrhistogram,org.latencyutils,${armeria.groupId},javax.inject,com.fasterxml.jackson.datatype
+            ${zipkin.groupId},org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,com.google.code.gson,org.reactivestreams,com.google.code.findbugs,javax.annotation,org.slf4j,io.netty,io.micrometer,org.hdrhistogram,org.latencyutils,${armeria.groupId},javax.inject,com.fasterxml.jackson.datatype,com.aayushatharva.brotli4j,commons-logging
           </excludeGroupIds>
           <excludes>
             <!-- zipkin-server depends on armeria and its grpc protocol-->

--- a/module/src/main/java/zipkin/module/aws/elasticsearch/AWSSignatureVersion4.java
+++ b/module/src/main/java/zipkin/module/aws/elasticsearch/AWSSignatureVersion4.java
@@ -41,7 +41,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import static com.linecorp.armeria.common.HttpHeaderNames.AUTHORITY;
 import static com.linecorp.armeria.common.HttpHeaderNames.HOST;
-import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 // http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
@@ -171,8 +170,8 @@ final class AWSSignatureVersion4 extends SimpleDecoratingHttpClient {
 
   static byte[] sha256(HttpData data) {
     final ByteBuffer buf;
-    if (data instanceof ByteBufHolder) {
-      buf = ((ByteBufHolder) data).content().nioBuffer();
+    if (data instanceof ByteBufHolder holder) {
+      buf = holder.content().nioBuffer();
     } else {
       buf = ByteBuffer.wrap(data.array());
     }
@@ -250,7 +249,7 @@ final class AWSSignatureVersion4 extends SimpleDecoratingHttpClient {
   }
 
   static String credentialScope(String yyyyMMdd, String region) {
-    return format("%s/%s/%s/%s", yyyyMMdd, region, SERVICE, "aws4_request");
+    return "%s/%s/%s/%s".formatted(yyyyMMdd, region, SERVICE, "aws4_request");
   }
 
   byte[] signatureKey(String secretKey, String yyyyMMdd) {

--- a/module/src/main/java/zipkin/module/aws/elasticsearch/ZipkinElasticsearchAwsStorageModule.java
+++ b/module/src/main/java/zipkin/module/aws/elasticsearch/ZipkinElasticsearchAwsStorageModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -44,8 +44,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
-import static java.lang.String.format;
-
 @Configuration
 @EnableConfigurationProperties(ZipkinElasticsearchAwsStorageProperties.class)
 @Conditional(ZipkinElasticsearchAwsStorageModule.AwsMagic.class)
@@ -87,10 +85,12 @@ class ZipkinElasticsearchAwsStorageModule {
     hosts = ZipkinElasticsearchAwsStorageProperties.emptyToNull(hosts);
     String domain = aws.getDomain();
     if (hosts != null && domain != null) {
-      log.warning(format(
-          "Expected exactly one of hosts or domain: instead saw hosts '%s' and domain '%s'."
-              + " Ignoring hosts and proceeding to look for domain. Either unset ES_HOSTS or "
-              + "ES_AWS_DOMAIN to suppress this message.",
+      log.warning((
+          """
+          Expected exactly one of hosts or domain: instead saw hosts '%s' and domain '%s'.\
+           Ignoring hosts and proceeding to look for domain. Either unset ES_HOSTS or \
+          ES_AWS_DOMAIN to suppress this message.\
+          """).formatted(
           hosts, domain));
     }
 
@@ -115,8 +115,8 @@ class ZipkinElasticsearchAwsStorageModule {
       @Override public AWSCredentials get() {
         com.amazonaws.auth.AWSCredentials result = delegate.getCredentials();
         String sessionToken =
-            result instanceof AWSSessionCredentials
-                ? ((AWSSessionCredentials) result).getSessionToken()
+            result instanceof AWSSessionCredentials awssc
+                ? awssc.getSessionToken()
                 : null;
         return new AWSCredentials(
             result.getAWSAccessKeyId(), result.getAWSSecretKey(), sessionToken);

--- a/module/src/main/java/zipkin/module/aws/kinesis/ZipkinKinesisCredentialsConfiguration.java
+++ b/module/src/main/java/zipkin/module/aws/kinesis/ZipkinKinesisCredentialsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -69,8 +69,8 @@ class ZipkinKinesisCredentialsConfiguration {
     AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
 
     // Create credentials provider from ID and secret if given.
-    if (!isNullOrEmpty(properties.getAwsAccessKeyId())
-        && !isNullOrEmpty(properties.getAwsSecretAccessKey())) {
+    if (notNullOrEmpty(properties.getAwsAccessKeyId())
+        && notNullOrEmpty(properties.getAwsSecretAccessKey())) {
       provider =
           new AWSStaticCredentialsProvider(
               new BasicAWSCredentials(properties.getAwsAccessKeyId(), properties.getAwsSecretAccessKey()));
@@ -79,8 +79,8 @@ class ZipkinKinesisCredentialsConfiguration {
     return provider;
   }
 
-  private static boolean isNullOrEmpty(String value) {
-    return (value == null || value.equals(""));
+  private static boolean notNullOrEmpty(String value) {
+    return (value != null && !value.isEmpty());
   }
 
   /**

--- a/module/src/main/java/zipkin/module/aws/sqs/ZipkinSQSCredentialsConfiguration.java
+++ b/module/src/main/java/zipkin/module/aws/sqs/ZipkinSQSCredentialsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -69,8 +69,8 @@ class ZipkinSQSCredentialsConfiguration {
     AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
 
     // Create credentials provider from ID and secret if given.
-    if (!isNullOrEmpty(properties.awsAccessKeyId)
-        && !isNullOrEmpty(properties.awsSecretAccessKey)) {
+    if (notNullOrEmpty(properties.awsAccessKeyId)
+        && notNullOrEmpty(properties.awsSecretAccessKey)) {
       provider =
           new AWSStaticCredentialsProvider(
               new BasicAWSCredentials(properties.awsAccessKeyId, properties.awsSecretAccessKey));
@@ -79,8 +79,8 @@ class ZipkinSQSCredentialsConfiguration {
     return provider;
   }
 
-  private static boolean isNullOrEmpty(String value) {
-    return (value == null || value.equals(""));
+  private static boolean notNullOrEmpty(String value) {
+    return (value != null && !value.isEmpty());
   }
 
   /**

--- a/module/src/test/java/zipkin/module/aws/elasticsearch/AWSSignatureVersion4Test.java
+++ b/module/src/test/java/zipkin/module/aws/elasticsearch/AWSSignatureVersion4Test.java
@@ -125,15 +125,16 @@ class AWSSignatureVersion4Test {
 
     writeCanonicalString(ctx, request.headers(), request.content(), result);
     // Ensure that the canonical string encodes commas with %2C
-    assertThat(result.toString(UTF_8)).isEqualTo(""
-        + "POST\n"
-        + "/zipkin-2016-10-05%2Czipkin-2016-10-06/dependencylink/_search\n"
-        + "allow_no_indices=true&expand_wildcards=open&ignore_unavailable=true\n"
-        + "host:search-zipkin-2rlyh66ibw43ftlk4342ceeewu.ap-southeast-1.es.amazonaws.com\n"
-        + "x-amz-date:20161004T132314Z\n"
-        + "\n"
-        + "host;x-amz-date\n"
-        + "2fd35cb36e5de91bbae279313c371fb630a6b3aab1478df378c5e73e667a1747");
+    assertThat(result.toString(UTF_8)).isEqualTo("""
+        POST
+        /zipkin-2016-10-05%2Czipkin-2016-10-06/dependencylink/_search
+        allow_no_indices=true&expand_wildcards=open&ignore_unavailable=true
+        host:search-zipkin-2rlyh66ibw43ftlk4342ceeewu.ap-southeast-1.es.amazonaws.com
+        x-amz-date:20161004T132314Z
+        
+        host;x-amz-date
+        2fd35cb36e5de91bbae279313c371fb630a6b3aab1478df378c5e73e667a1747\
+        """);
   }
 
   /** Starting with Zipkin 1.31 colons are used to delimit index types in ES */
@@ -153,15 +154,16 @@ class AWSSignatureVersion4Test {
     writeCanonicalString(ctx, request.headers(), request.content(), result);
 
     // Ensure that the canonical string encodes commas with %2C
-    assertThat(result.toString(UTF_8)).isEqualTo(""
-        + "GET\n"
-        + "/_cluster/health/zipkin%3Aspan-%2A\n"
-        + "\n"
-        + "host:search-zipkin53-mhdyquzbwwzwvln6phfzr3mmdi.ap-southeast-1.es.amazonaws.com\n"
-        + "x-amz-date:20170830T143137Z\n"
-        + "\n"
-        + "host;x-amz-date\n"
-        + "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assertThat(result.toString(UTF_8)).isEqualTo("""
+        GET
+        /_cluster/health/zipkin%3Aspan-%2A
+        
+        host:search-zipkin53-mhdyquzbwwzwvln6phfzr3mmdi.ap-southeast-1.es.amazonaws.com
+        x-amz-date:20170830T143137Z
+        
+        host;x-amz-date
+        e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\
+        """);
   }
 
   @Test void canonicalString_getDomain() {
@@ -180,24 +182,24 @@ class AWSSignatureVersion4Test {
 
     writeCanonicalString(ctx, request.headers(), request.content(),
         canonicalString);
-    assertThat(canonicalString.toString(UTF_8)).isEqualTo(""
-        + "GET\n"
-        + "/2015-01-01/es/domain/zipkin\n"
-        + "\n"
-        + "host:es.ap-southeast-1.amazonaws.com\n"
-        + "x-amz-date:" + timestamp + "\n"
-        + "\n"
-        + "host;x-amz-date\n"
-        + "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assertThat(canonicalString.toString(UTF_8)).isEqualTo("GET\n"
+                                                          + "/2015-01-01/es/domain/zipkin\n"
+                                                          + "\n"
+                                                          + "host:es.ap-southeast-1.amazonaws.com\n"
+                                                          + "x-amz-date:" + timestamp + "\n"
+                                                          + "\n"
+                                                          + "host;x-amz-date\n"
+                                                          + "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
     ByteBuf toSign = Unpooled.buffer();
     AWSSignatureVersion4.writeToSign(timestamp,
         AWSSignatureVersion4.credentialScope(yyyyMMdd, "ap-southeast-1"), canonicalString, toSign);
 
-    assertThat(toSign.toString(UTF_8)).isEqualTo(""
-        + "AWS4-HMAC-SHA256\n"
-        + "20190730T134617Z\n"
-        + "20190730/ap-southeast-1/es/aws4_request\n"
-        + "129dd8ded740553cd28544b4000982b8f88d7199b36a013fa89ee8e56c23f80e");
+    assertThat(toSign.toString(UTF_8)).isEqualTo("""
+        AWS4-HMAC-SHA256
+        20190730T134617Z
+        20190730/ap-southeast-1/es/aws4_request
+        129dd8ded740553cd28544b4000982b8f88d7199b36a013fa89ee8e56c23f80e\
+        """);
   }
 }

--- a/module/src/test/java/zipkin/module/aws/elasticsearch/ElasticsearchDomainEndpointTest.java
+++ b/module/src/test/java/zipkin/module/aws/elasticsearch/ElasticsearchDomainEndpointTest.java
@@ -64,12 +64,14 @@ class ElasticsearchDomainEndpointTest {
     MOCK_RESPONSE.set(AggregatedHttpResponse.of(
         HttpStatus.OK,
         MediaType.JSON_UTF_8,
-        "{\n"
-            + "  \"DomainStatus\": {\n"
-            + "    \"Endpoint\": \"search-zipkin53-mhdyquzbwwzwvln6phfzr3lldi.ap-southeast-1.es.amazonaws.com\",\n"
-            + "    \"Endpoints\": null\n"
-            + "  }\n"
-            + "}"));
+        """
+        {
+          "DomainStatus": {
+            "Endpoint": "search-zipkin53-mhdyquzbwwzwvln6phfzr3lldi.ap-southeast-1.es.amazonaws.com",
+            "Endpoints": null
+          }
+        }\
+        """));
 
     assertThat(client.get()).extracting("hostname")
         .isEqualTo(
@@ -80,14 +82,16 @@ class ElasticsearchDomainEndpointTest {
     MOCK_RESPONSE.set(AggregatedHttpResponse.of(
         HttpStatus.OK,
         MediaType.JSON_UTF_8,
-        "{\n"
-            + "  \"DomainStatus\": {\n"
-            + "    \"Endpoint\": null,\n"
-            + "    \"Endpoints\": {\n"
-            + "      \"vpc\":\"search-zipkin53-mhdyquzbwwzwvln6phfzr3lldi.ap-southeast-1.es.amazonaws.com\"\n"
-            + "    }\n"
-            + "  }\n"
-            + "}"));
+        """
+        {
+          "DomainStatus": {
+            "Endpoint": null,
+            "Endpoints": {
+              "vpc":"search-zipkin53-mhdyquzbwwzwvln6phfzr3lldi.ap-southeast-1.es.amazonaws.com"
+            }
+          }
+        }\
+        """));
 
     assertThat(client.get()).extracting("hostname")
         .isEqualTo(
@@ -98,14 +102,16 @@ class ElasticsearchDomainEndpointTest {
     MOCK_RESPONSE.set(AggregatedHttpResponse.of(
         HttpStatus.OK,
         MediaType.JSON_UTF_8,
-        "{\n"
-            + "  \"DomainStatus\": {\n"
-            + "    \"Endpoint\": \"isnotvpc\",\n"
-            + "    \"Endpoints\": {\n"
-            + "      \"vpc\":\"isvpc\"\n"
-            + "    }\n"
-            + "  }\n"
-            + "}"));
+        """
+        {
+          "DomainStatus": {
+            "Endpoint": "isnotvpc",
+            "Endpoints": {
+              "vpc":"isvpc"
+            }
+          }
+        }\
+        """));
 
     assertThat(client.get()).extracting("hostname")
         .isEqualTo("isvpc");
@@ -115,12 +121,14 @@ class ElasticsearchDomainEndpointTest {
     MOCK_RESPONSE.set(AggregatedHttpResponse.of(
         HttpStatus.OK,
         MediaType.JSON_UTF_8,
-        "{\n"
-            + "  \"DomainStatus\": {\n"
-            + "    \"Endpoint\": \"isnotvpc\",\n"
-            + "    \"Endpoints\": {}\n"
-            + "  }\n"
-            + "}"));
+        """
+        {
+          "DomainStatus": {
+            "Endpoint": "isnotvpc",
+            "Endpoints": {}
+          }
+        }\
+        """));
 
     assertThat(client.get()).extracting("hostname")
         .isEqualTo("isnotvpc");

--- a/pom.xml
+++ b/pom.xml
@@ -70,23 +70,24 @@
     <maven.compiler.release>8</maven.compiler.release>
 
     <!-- Tests use the floor Java version (used in release) -->
-    <maven.compiler.testSource>11</maven.compiler.testSource>
-    <maven.compiler.testTarget>11</maven.compiler.testTarget>
-    <maven.compiler.testRelease>11</maven.compiler.testRelease>
+    <maven.compiler.testSource>17</maven.compiler.testSource>
+    <maven.compiler.testTarget>17</maven.compiler.testTarget>
+    <maven.compiler.testRelease>17</maven.compiler.testRelease>
 
     <!-- groupId overrides allow testing feature branches with jitpack -->
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>2.27.1</zipkin.version>
-    <zipkin-reporter.version>3.0.2</zipkin-reporter.version>
-    <spring-boot.version>2.7.18</spring-boot.version>
+    <zipkin.version>3.0.0-SNAPSHOT</zipkin.version>
+    <zipkin-reporter.version>3.1.1</zipkin-reporter.version>
+    <spring-boot.version>3.2.1</spring-boot.version>
     <jackson.version>2.16.1</jackson.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>1.26.4</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
     <netty.version>4.1.100.Final</netty.version>
+    <log4j.version>2.21.1</log4j.version>
 
     <!-- This allows you to test feature branches with jitpack -->
     <!--    <brave.groupId>com.github.openzipkin.brave</brave.groupId>-->
@@ -97,7 +98,6 @@
     <aws-java-sdk.version>1.12.633</aws-java-sdk.version>
     <sdk-core.version>2.22.13</sdk-core.version>
 
-    <log4j.version>2.22.1</log4j.version>
     <okhttp.version>4.12.0</okhttp.version>
 
     <assertj.version>3.25.1</assertj.version>
@@ -169,6 +169,22 @@
       <url>https://gitter.im/openzipkin/zipkin</url>
     </developer>
   </developers>
+
+
+  <!-- TODO: delete -->
+  <repositories>
+    <repository>
+      <id>sonatype.snapshots</id>
+      <name>Sonatype Snapshot Repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <dependencyManagement>
     <!-- Be careful here, especially to not import BOMs as it causes version confusion.

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>3.0.0-SNAPSHOT</zipkin.version>
+    <zipkin.version>3.0.0</zipkin.version>
     <zipkin-reporter.version>3.1.1</zipkin-reporter.version>
     <spring-boot.version>3.2.1</spring-boot.version>
     <jackson.version>2.16.1</jackson.version>
@@ -169,22 +169,6 @@
       <url>https://gitter.im/openzipkin/zipkin</url>
     </developer>
   </developers>
-
-
-  <!-- TODO: delete -->
-  <repositories>
-    <repository>
-      <id>sonatype.snapshots</id>
-      <name>Sonatype Snapshot Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 
   <dependencyManagement>
     <!-- Be careful here, especially to not import BOMs as it causes version confusion.

--- a/reporter/reporter-xray-udp/src/main/java/zipkin2/reporter/xray_udp/XRayUDPReporter.java
+++ b/reporter/reporter-xray-udp/src/main/java/zipkin2/reporter/xray_udp/XRayUDPReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,7 +25,7 @@ import zipkin2.storage.xray_udp.XRayUDPStorage;
 
 /**
  * Reports Zipkin spans to AWS X-Ray via the X-Ray daemon, contacted using UDP.
- *
+ * <p>
  * Note that, unlike AsyncReporter, this reporter attempts to encode and send
  * the span immediately on the calling thread. As UDP is used, there is no
  * latency in waiting for the daemon to accept and respond to the data.

--- a/reporter/sender-awssdk-sqs/src/test/java/zipkin2/reporter/awssdk/sqs/SQSSenderTest.java
+++ b/reporter/sender-awssdk-sqs/src/test/java/zipkin2/reporter/awssdk/sqs/SQSSenderTest.java
@@ -39,40 +39,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 
 class SQSSenderTest {
-  @RegisterExtension AmazonSQSExtension sqs = new AmazonSQSExtension();
+  @RegisterExtension
+  AmazonSQSExtension sqs = new AmazonSQSExtension();
 
-  private SqsClient sqsClient;
   private SQSSender sender;
 
-  @BeforeEach public void setup() {
-    sqsClient = SqsClient.builder()
-      .httpClient(UrlConnectionHttpClient.create())
-      .region(Region.US_EAST_1)
-      .endpointOverride(URI.create(sqs.queueUrl()))
-      .credentialsProvider(
-          StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
-      .build();
+  @BeforeEach
+  public void setup() {
+    SqsClient sqsClient = SqsClient.builder()
+        .httpClient(UrlConnectionHttpClient.create())
+        .region(Region.US_EAST_1)
+        .endpointOverride(URI.create(sqs.queueUrl()))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("x", "x")))
+        .build();
 
     sender = SQSSender.newBuilder()
-      .queueUrl(sqs.queueUrl())
-      .sqsClient(sqsClient)
-      .build();
+        .queueUrl(sqs.queueUrl())
+        .sqsClient(sqsClient)
+        .build();
   }
 
-  @Test void sendsSpans() throws Exception {
+  @Test
+  void sendsSpans() throws Exception {
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
     assertThat(readSpans()).containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test void sendsSpans_json_unicode() throws Exception {
+  @Test
+  void sendsSpans_json_unicode() throws Exception {
     Span unicode = CLIENT_SPAN.toBuilder().putTag("error", "\uD83D\uDCA9").build();
     send(unicode).execute();
 
     assertThat(readSpans()).containsExactly(unicode);
   }
 
-  @Test void sendsSpans_PROTO3() throws Exception {
+  @Test
+  void sendsSpans_PROTO3() throws Exception {
     sender.close();
     sender = sender.toBuilder().encoding(Encoding.PROTO3).build();
 
@@ -81,30 +86,31 @@ class SQSSenderTest {
     assertThat(readSpans()).containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test void outOfBandCancel() throws Exception {
+  @Test
+  void outOfBandCancel() throws Exception {
     SQSSender.SQSCall call = (SQSSender.SQSCall) send(CLIENT_SPAN, CLIENT_SPAN);
     assertThat(call.isCanceled()).isFalse(); // sanity check
 
     CountDownLatch latch = new CountDownLatch(1);
-    call.enqueue(
-        new Callback<Void>() {
-          @Override
-          public void onSuccess(Void aVoid) {
-            call.cancel();
-            latch.countDown();
-          }
+    call.enqueue(new Callback<>() {
+      @Override
+      public void onSuccess(Void aVoid) {
+        call.cancel();
+        latch.countDown();
+      }
 
-          @Override
-          public void onError(Throwable throwable) {
-            latch.countDown();
-          }
-        });
+      @Override
+      public void onError(Throwable throwable) {
+        latch.countDown();
+      }
+    });
 
     latch.await(5, TimeUnit.SECONDS);
     assertThat(call.isCanceled()).isTrue();
   }
 
-  @Test void checkOk() {
+  @Test
+  void checkOk() {
     assertThat(sender.check()).isEqualTo(CheckResult.OK);
   }
 

--- a/storage/xray-udp/pom.xml
+++ b/storage/xray-udp/pom.xml
@@ -28,6 +28,11 @@
 
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <!-- Only used in zipkin-server, which has floor JRE 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/storage/xray-udp/src/main/java/zipkin2/storage/xray_udp/XRayUDPStorage.java
+++ b/storage/xray-udp/src/main/java/zipkin2/storage/xray_udp/XRayUDPStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -36,13 +36,7 @@ import zipkin2.storage.StorageComponent;
 public final class XRayUDPStorage extends StorageComponent implements SpanStore, SpanConsumer {
 
   static final int PACKET_LENGTH = 256 * 1024;
-  static final ThreadLocal<byte[]> BUF =
-      new ThreadLocal<byte[]>() {
-        @Override
-        protected byte[] initialValue() {
-          return new byte[PACKET_LENGTH];
-        }
-      };
+  static final ThreadLocal<byte[]> BUF = ThreadLocal.withInitial(() -> new byte[PACKET_LENGTH]);
 
   public static Builder newBuilder() {
     return new Builder();
@@ -178,7 +172,7 @@ public final class XRayUDPStorage extends StorageComponent implements SpanStore,
     }
   }
 
-  @Override public final String toString() {
+  @Override public String toString() {
     return "XRayUDPStorage{address=" + address + "}";
   }
 

--- a/storage/xray-udp/src/test/java/zipkin2/storage/xray_udp/XRayUDPStorageTest.java
+++ b/storage/xray-udp/src/test/java/zipkin2/storage/xray_udp/XRayUDPStorageTest.java
@@ -104,7 +104,7 @@ class XRayUDPStorageTest {
     assertThat(receivedPayloads).isEmpty();
   }
 
-  @Test void sendAfterClose() throws Exception {
+  @Test void sendAfterClose() {
     XRayUDPStorage storage = XRayUDPStorage.newBuilder()
         .address("localhost:" + ((InetSocketAddress)serverChannel.localAddress()).getPort())
         .build();


### PR DESCRIPTION
This updates server modules to Zipkin 3, Spring Boot 3 and JRE 17. It leaves the client side modules at Java 8.

In order to compile the server module, we can no longer compile with JDK 11.

See https://github.com/openzipkin/zipkin/pull/3684