### PR TITLE
Migrates zipkin-aws to v2 SDK; add v2 sender/instrumentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,10 +14,12 @@
 !brave/instrumentation-aws-java-sdk-core/src/main/**
 !brave/instrumentation-aws-java-sdk-v2-core/src/main/**
 !brave/instrumentation-aws-java-sdk-sqs/src/main/**
+!brave/instrumentation-awssdk-sqs/src/main/**
 !brave/propagation-aws/src/main/**
 !module/src/main/**
 !reporter/reporter-xray-udp/src/main/**
 !reporter/sender-awssdk-sqs/src/main/**
+!reporter/sender-awssdk-kinesis/src/main/**
 !reporter/sender-kinesis/src/main/**
 !reporter/sender-sqs/src/main/**
 !storage/xray-udp/src/main/**

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Instrumentation | Description
 [AWS SDK](brave/instrumentation-aws-java-sdk-core) | Traces [AmazonWebServiceClient](https://github.com/aws/aws-sdk-java)
 [AWS SDK V2](brave/instrumentation-aws-java-sdk-v2-core) | Traces [SdkClient](https://github.com/aws/aws-sdk-java-v2)
 [AWS SQS Messaging](brave/instrumentation-aws-java-sdk-sqs) | Traces [AmazonSQS](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/AmazonSQS.html)
+[AWS SQS V2 Messaging](brave/instrumentation-awssdk-sqs) | Traces [SqsClient](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/sqs/SqsClient.html)
 
 We also have a [library to read Amazon's trace header](brave/propagation-aws).
 
@@ -49,6 +50,7 @@ Sender | Description
 [SQS](reporter/sender-sqs) | Sends tracing data to Zipkin using [SQS](https://aws.amazon.com/sqs/), a message queue service.
 [SQS v2](reporter/sender-awssdk-sqs) | Sends tracing data to Zipkin using [SQS](https://aws.amazon.com/sqs/), a message queue service.
 [Kinesis](reporter/sender-kinesis) | Sends tracing data to Zipkin using [Kinesis](https://aws.amazon.com/kinesis/), an alternative similar to Kafka.
+[Kinesis v2](reporter/sender-awssdk-kinesis) | Sends tracing data to Zipkin using [Kinesis](https://aws.amazon.com/kinesis/) with the [V2 AWS SDK](https://github.com/aws/aws-sdk-java-v2).
 
 ## Collectors
 The component in a zipkin server that receives trace data is called a

--- a/aws-junit/pom.xml
+++ b/aws-junit/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-aws-junit</artifactId>
@@ -56,21 +56,14 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sqs</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sqs</artifactId>
+      <version>${sdk-core.version}</version>
     </dependency>
-
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>url-connection-client</artifactId>
+      <version>${sdk-core.version}</version>
     </dependency>
 
     <dependency>

--- a/aws-junit/src/main/java/zipkin2/junit/aws/AmazonSQSExtension.java
+++ b/aws-junit/src/main/java/zipkin2/junit/aws/AmazonSQSExtension.java
@@ -4,17 +4,8 @@
  */
 package zipkin2.junit.aws;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import com.amazonaws.services.sqs.model.DeleteMessageRequest;
-import com.amazonaws.services.sqs.model.Message;
-import com.amazonaws.services.sqs.model.PurgeQueueRequest;
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
-import com.amazonaws.util.Base64;
+import java.net.URI;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -24,6 +15,18 @@ import org.elasticmq.rest.sqs.SQSRestServerBuilder;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesDecoder;
 
@@ -33,7 +36,7 @@ import static java.util.Collections.singletonList;
 public class AmazonSQSExtension implements BeforeEachCallback, AfterEachCallback {
   SQSRestServer server;
   int serverPort;
-  AmazonSQS client;
+  SqsClient client;
   String queueUrl;
 
   public AmazonSQSExtension() {
@@ -47,22 +50,24 @@ public class AmazonSQSExtension implements BeforeEachCallback, AfterEachCallback
     }
 
     if (client == null) {
-      client = AmazonSQSClientBuilder.standard()
-          .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("x", "x")))
-          .withEndpointConfiguration(
-              new EndpointConfiguration("http://localhost:%d".formatted(serverPort), null))
+      client = SqsClient.builder()
+          .httpClient(UrlConnectionHttpClient.create())
+          .credentialsProvider(
+              StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
+          .endpointOverride(URI.create("http://localhost:%d".formatted(serverPort)))
+          .region(Region.US_EAST_1)
           .build();
-      queueUrl = client.createQueue("zipkin").getQueueUrl();
+      queueUrl = client.createQueue(b -> b.queueName("zipkin")).queueUrl();
     }
-    
+
     if (client != null && queueUrl != null) {
-      client.purgeQueue(new PurgeQueueRequest(queueUrl));
+      client.purgeQueue(PurgeQueueRequest.builder().queueUrl(queueUrl).build());
     }
   }
 
   @Override public void afterEach(ExtensionContext extensionContext) {
     if (client != null) {
-      client.shutdown();
+      client.close();
       client = null;
     }
 
@@ -77,18 +82,19 @@ public class AmazonSQSExtension implements BeforeEachCallback, AfterEachCallback
   }
 
   public int queueCount() {
-    String count = client.getQueueAttributes(queueUrl, singletonList("ApproximateNumberOfMessages"))
-        .getAttributes()
-        .get("ApproximateNumberOfMessages");
+    String count = client.getQueueAttributes(b -> b.queueUrl(queueUrl)
+            .attributeNames(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES))
+        .attributes()
+        .get(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES);
 
     return Integer.parseInt(count);
   }
 
   public int notVisibleCount() {
-    String count =
-        client.getQueueAttributes(queueUrl, singletonList("ApproximateNumberOfMessagesNotVisible"))
-            .getAttributes()
-            .get("ApproximateNumberOfMessagesNotVisible");
+    String count = client.getQueueAttributes(b -> b.queueUrl(queueUrl)
+            .attributeNames(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE))
+        .attributes()
+        .get(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES_NOT_VISIBLE);
 
     return Integer.parseInt(count);
   }
@@ -101,19 +107,24 @@ public class AmazonSQSExtension implements BeforeEachCallback, AfterEachCallback
 
     Stream<Span> spans = Stream.empty();
 
-    ReceiveMessageResult result = client.receiveMessage(queueUrl);
+    ReceiveMessageResponse result = client.receiveMessage(
+        ReceiveMessageRequest.builder().queueUrl(queueUrl).build());
 
-    while (result != null && !result.getMessages().isEmpty()) {
+    while (result != null && !result.messages().isEmpty()) {
 
       spans = Stream.concat(spans,
-          result.getMessages().stream().flatMap(AmazonSQSExtension::decodeSpans));
+          result.messages().stream().flatMap(AmazonSQSExtension::decodeSpans));
 
-      result = client.receiveMessage(queueUrl);
+      result = client.receiveMessage(
+          ReceiveMessageRequest.builder().queueUrl(queueUrl).build());
 
       if (delete) {
-        List<DeleteMessageRequest> deletes = result.getMessages()
+        List<DeleteMessageRequest> deletes = result.messages()
             .stream()
-            .map(m -> new DeleteMessageRequest(queueUrl, m.getReceiptHandle()))
+            .map(m -> DeleteMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(m.receiptHandle())
+                .build())
             .toList();
         deletes.forEach(d -> client.deleteMessage(d));
       }
@@ -123,12 +134,15 @@ public class AmazonSQSExtension implements BeforeEachCallback, AfterEachCallback
   }
 
   public void send(String body) {
-    client.sendMessage(new SendMessageRequest(queueUrl, body));
+    client.sendMessage(SendMessageRequest.builder()
+        .queueUrl(queueUrl)
+        .messageBody(body)
+        .build());
   }
 
   static Stream<? extends Span> decodeSpans(Message m) {
     byte[] bytes =
-        m.getBody().charAt(0) == '[' ? m.getBody().getBytes(UTF_8) : Base64.decode(m.getBody());
+        m.body().charAt(0) == '[' ? m.body().getBytes(UTF_8) : Base64.getDecoder().decode(m.body());
     if (bytes[0] == '[') {
       return SpanBytesDecoder.JSON_V2.decodeList(bytes).stream();
     }

--- a/brave/instrumentation-aws-java-sdk-core/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-core/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/instrumentation-aws-java-sdk-sqs/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-sqs/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/instrumentation-aws-java-sdk-v2-core/pom.xml
+++ b/brave/instrumentation-aws-java-sdk-v2-core/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/brave/instrumentation-awssdk-sqs/README.md
+++ b/brave/instrumentation-awssdk-sqs/README.md
@@ -1,0 +1,32 @@
+# AWS SQS V2 Messaging Instrumentation
+
+This module contains instrumentation for AWS SDK V2 `SqsClient` `SendMessage*` request types.
+
+The `SqsMessageTracing` type provides an `ExecutionInterceptor` instance that can be added to your
+clients at build time. It adds tracing headers to both `SendMessageRequest` and
+`SendMessageBatchRequest` types. In the case of `SendMessageBatchRequest` each message in the batch
+gets its own `Span` and headers added.
+
+## Usage
+
+You will want to create your SQS client and add the execution interceptor:
+
+```java
+Tracing tracing = ...;
+SqsMessageTracing sqsMessageTracing = SqsMessageTracing.create(tracing);
+
+ClientOverrideConfiguration configuration = ClientOverrideConfiguration.builder()
+    .addExecutionInterceptor(sqsMessageTracing.executionInterceptor())
+    .build();
+
+SqsClient client = SqsClient.builder()
+    .overrideConfiguration(configuration)
+    .build();
+```
+
+Now use your SQS client as you normally would and spans will be attached to outgoing messages.
+
+## Notes
+
+* This is the V2 SDK equivalent of [instrumentation-aws-java-sdk-sqs](../instrumentation-aws-java-sdk-sqs).
+* This can be combined with [instrumentation-aws-java-sdk-v2-core](../instrumentation-aws-java-sdk-v2-core) on the same client to get both HTTP-level CLIENT spans and message-level PRODUCER spans.

--- a/brave/instrumentation-awssdk-sqs/pom.xml
+++ b/brave/instrumentation-awssdk-sqs/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>zipkin-aws-parent</artifactId>
+    <groupId>io.zipkin.aws</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>brave-instrumentation-awssdk-sqs</artifactId>
+  <name>Brave Instrumentation: AWS SDK V2 SQS</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+      <version>${brave.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sqs</artifactId>
+      <version>${sdk-core.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-context-log4j2</artifactId>
+      <version>${brave.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-tests</artifactId>
+      <version>${brave.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/brave/instrumentation-awssdk-sqs/src/main/java/brave/instrumentation/awssdk/sqs/SendMessageTracingExecutionInterceptor.java
+++ b/brave/instrumentation-awssdk-sqs/src/main/java/brave/instrumentation/awssdk/sqs/SendMessageTracingExecutionInterceptor.java
@@ -101,7 +101,7 @@ final class SendMessageTracingExecutionInterceptor implements ExecutionIntercept
       span = tracer.newChild(maybeParent);
     }
 
-    span.name("publish-batch").remoteServiceName("amazon-sqs").start();
+    span.name("publish-batch").kind(PRODUCER).remoteServiceName("amazon-sqs").start();
     List<SendMessageBatchRequestEntry> modifiedEntries;
     try (SpanInScope scope = tracer.withSpanInScope(span)) {
       modifiedEntries = new ArrayList<>(request.entries().size());

--- a/brave/instrumentation-awssdk-sqs/src/main/java/brave/instrumentation/awssdk/sqs/SendMessageTracingExecutionInterceptor.java
+++ b/brave/instrumentation-awssdk-sqs/src/main/java/brave/instrumentation/awssdk/sqs/SendMessageTracingExecutionInterceptor.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.instrumentation.awssdk.sqs;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracer.SpanInScope;
+import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.Propagation.RemoteGetter;
+import brave.propagation.Propagation.RemoteSetter;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContext.Extractor;
+import brave.propagation.TraceContext.Injector;
+import brave.propagation.TraceContextOrSamplingFlags;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import static brave.Span.Kind.PRODUCER;
+
+final class SendMessageTracingExecutionInterceptor implements ExecutionInterceptor {
+
+  static final RemoteSetter<Map<String, MessageAttributeValue>> SETTER =
+      new RemoteSetter<Map<String, MessageAttributeValue>>() {
+        @Override public Span.Kind spanKind() {
+          return PRODUCER;
+        }
+
+        @Override public void put(Map<String, MessageAttributeValue> carrier, String key,
+            String value) {
+          carrier.put(key,
+              MessageAttributeValue.builder().dataType("String").stringValue(value).build());
+        }
+      };
+
+  static final RemoteGetter<Map<String, MessageAttributeValue>> GETTER =
+      new RemoteGetter<Map<String, MessageAttributeValue>>() {
+        @Override public Span.Kind spanKind() {
+          return PRODUCER;
+        }
+
+        @Override public String get(Map<String, MessageAttributeValue> carrier, String key) {
+          MessageAttributeValue value = carrier.get(key);
+          return value != null ? value.stringValue() : null;
+        }
+      };
+
+  final Tracing tracing;
+  final Tracer tracer;
+  final CurrentTraceContext currentTraceContext;
+  final Injector<Map<String, MessageAttributeValue>> injector;
+  final Extractor<Map<String, MessageAttributeValue>> extractor;
+
+  SendMessageTracingExecutionInterceptor(Tracing tracing) {
+    this.tracing = tracing;
+    this.tracer = tracing.tracer();
+    this.currentTraceContext = tracing.currentTraceContext();
+    this.injector = tracing.propagation().injector(SETTER);
+    this.extractor = tracing.propagation().extractor(GETTER);
+  }
+
+  @Override
+  public SdkRequest modifyRequest(Context.ModifyRequest context,
+      ExecutionAttributes executionAttributes) {
+    SdkRequest request = context.request();
+    if (request instanceof SendMessageRequest) {
+      return handleSendMessageRequest((SendMessageRequest) request);
+    } else if (request instanceof SendMessageBatchRequest) {
+      return handleSendMessageBatchRequest((SendMessageBatchRequest) request);
+    }
+    return request;
+  }
+
+  private SdkRequest handleSendMessageRequest(SendMessageRequest request) {
+    Map<String, MessageAttributeValue> mutableAttributes =
+        new LinkedHashMap<>(request.messageAttributes());
+    injectPerMessage(request.queueUrl(), mutableAttributes);
+    return request.toBuilder().messageAttributes(mutableAttributes).build();
+  }
+
+  private SdkRequest handleSendMessageBatchRequest(SendMessageBatchRequest request) {
+    TraceContext maybeParent = currentTraceContext.get();
+
+    Span span;
+    if (maybeParent == null) {
+      span = tracer.nextSpan();
+    } else {
+      // If we have a span in scope assume headers were cleared before
+      span = tracer.newChild(maybeParent);
+    }
+
+    span.name("publish-batch").remoteServiceName("amazon-sqs").start();
+    List<SendMessageBatchRequestEntry> modifiedEntries;
+    try (SpanInScope scope = tracer.withSpanInScope(span)) {
+      modifiedEntries = new ArrayList<>(request.entries().size());
+      for (SendMessageBatchRequestEntry entry : request.entries()) {
+        Map<String, MessageAttributeValue> mutableAttributes =
+            new LinkedHashMap<>(entry.messageAttributes());
+        injectPerMessage(request.queueUrl(), mutableAttributes);
+        modifiedEntries.add(
+            entry.toBuilder().messageAttributes(mutableAttributes).build());
+      }
+    } finally {
+      span.finish();
+    }
+
+    return request.toBuilder().entries(modifiedEntries).build();
+  }
+
+  private void injectPerMessage(String queueUrl,
+      Map<String, MessageAttributeValue> messageAttributes) {
+    TraceContext maybeParent = currentTraceContext.get();
+
+    Span span;
+    if (maybeParent == null) {
+      span = tracer.nextSpan(extractAndClearHeaders(messageAttributes));
+    } else {
+      // If we have a span in scope assume headers were cleared before
+      span = tracer.newChild(maybeParent);
+    }
+
+    if (!span.isNoop()) {
+      span.kind(PRODUCER).name("publish");
+      span.remoteServiceName("amazon-sqs");
+      span.tag("queue.url", queueUrl);
+      // incur timestamp overhead only once
+      long timestamp = tracing.clock(span.context()).currentTimeMicroseconds();
+      span.start(timestamp).finish(timestamp);
+    }
+
+    injector.inject(span.context(), messageAttributes);
+  }
+
+  private TraceContextOrSamplingFlags extractAndClearHeaders(
+      Map<String, MessageAttributeValue> messageAttributes) {
+    TraceContextOrSamplingFlags extracted = extractor.extract(messageAttributes);
+
+    for (String propagationKey : tracing.propagation().keys()) {
+      messageAttributes.remove(propagationKey);
+    }
+
+    return extracted;
+  }
+}

--- a/brave/instrumentation-awssdk-sqs/src/main/java/brave/instrumentation/awssdk/sqs/SqsMessageTracing.java
+++ b/brave/instrumentation-awssdk-sqs/src/main/java/brave/instrumentation/awssdk/sqs/SqsMessageTracing.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.instrumentation.awssdk.sqs;
+
+import brave.Tracing;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+
+public class SqsMessageTracing {
+  public static SqsMessageTracing create(Tracing tracing) {
+    return new SqsMessageTracing(tracing);
+  }
+
+  final ExecutionInterceptor executionInterceptor;
+
+  private SqsMessageTracing(Tracing tracing) {
+    this.executionInterceptor = new SendMessageTracingExecutionInterceptor(tracing);
+  }
+
+  public ExecutionInterceptor executionInterceptor() {
+    return executionInterceptor;
+  }
+}

--- a/brave/instrumentation-awssdk-sqs/src/test/java/brave/instrumentation/awssdk/sqs/SendMessageTracingExecutionInterceptorTest.java
+++ b/brave/instrumentation-awssdk-sqs/src/test/java/brave/instrumentation/awssdk/sqs/SendMessageTracingExecutionInterceptorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package brave.instrumentation.awssdk.sqs;
+
+import brave.Tracing;
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext.Extractor;
+import brave.propagation.TraceContextOrSamplingFlags;
+import brave.test.TestSpanHandler;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import static brave.Span.Kind.PRODUCER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SendMessageTracingExecutionInterceptorTest {
+  TestSpanHandler spans = new TestSpanHandler();
+  Tracing tracing = Tracing.newBuilder().addSpanHandler(spans).build();
+  Extractor<Map<String, MessageAttributeValue>> extractor =
+      tracing.propagation().extractor(SendMessageTracingExecutionInterceptor.GETTER);
+  SendMessageTracingExecutionInterceptor interceptor =
+      new SendMessageTracingExecutionInterceptor(tracing);
+
+  @AfterEach void cleanup() {
+    tracing.close();
+  }
+
+  @Test void handleSendMessageRequest() {
+    SendMessageRequest request = SendMessageRequest.builder()
+        .queueUrl("queueUrl")
+        .messageBody("test message content")
+        .build();
+
+    SdkRequest modified = interceptor.modifyRequest(
+        modifyRequestContext(request), ExecutionAttributes.builder().build());
+
+    // Verify propagation
+    SendMessageRequest result = (SendMessageRequest) modified;
+    verifyInjectedTraceContext(result.messageAttributes(), null);
+
+    // Verify Span
+    assertThat(spans).hasSize(1);
+    MutableSpan reportedSpan = spans.get(0);
+    verifyReportedPublishSpan(reportedSpan);
+  }
+
+  @Test void handleSendMessageBatchRequest() {
+    SendMessageBatchRequest request = SendMessageBatchRequest.builder()
+        .queueUrl("queueUrl")
+        .entries(
+            SendMessageBatchRequestEntry.builder()
+                .id("id1").messageBody("test message body 1").build(),
+            SendMessageBatchRequestEntry.builder()
+                .id("id2").messageBody("test message body 2").build())
+        .build();
+
+    SdkRequest modified = interceptor.modifyRequest(
+        modifyRequestContext(request), ExecutionAttributes.builder().build());
+
+    assertThat(spans).hasSize(3);
+
+    MutableSpan localParent =
+        spans.spans().stream().filter(s -> s.parentId() == null).findFirst().get();
+
+    // Verify propagation
+    SendMessageBatchRequest result = (SendMessageBatchRequest) modified;
+    for (SendMessageBatchRequestEntry entry : result.entries()) {
+      verifyInjectedTraceContext(entry.messageAttributes(), localParent);
+    }
+
+    // Verify Span
+    assertThat(localParent.name()).isEqualTo("publish-batch");
+
+    List<MutableSpan> messageSpans =
+        spans.spans().stream().filter(s -> s != localParent).collect(Collectors.toList());
+    for (MutableSpan span : messageSpans) {
+      verifyReportedPublishSpan(span);
+    }
+  }
+
+  private void verifyInjectedTraceContext(Map<String, MessageAttributeValue> messageAttributes,
+      MutableSpan parent) {
+    TraceContextOrSamplingFlags extracted = extractor.extract(messageAttributes);
+
+    assertThat(extracted.sampled()).isTrue();
+    assertThat(extracted.traceIdContext()).isNull();
+    assertThat(extracted.context()).isNotNull();
+
+    if (parent == null) {
+      assertThat(extracted.context().traceIdString()).isNotEmpty();
+    } else {
+      assertThat(extracted.context().traceIdString()).isEqualTo(parent.traceId());
+    }
+    assertThat(extracted.context().spanIdString()).isNotEmpty();
+  }
+
+  private void verifyReportedPublishSpan(MutableSpan span) {
+    assertThat(span.kind()).isEqualTo(PRODUCER);
+    assertThat(span.name()).isEqualTo("publish");
+    assertThat(span.remoteServiceName()).isEqualToIgnoringCase("amazon-sqs");
+    assertThat(span.tags().get("queue.url")).isEqualToIgnoringCase("queueUrl");
+    assertThat(span.finishTimestamp() - span.startTimestamp()).isZero();
+  }
+
+  static Context.ModifyRequest modifyRequestContext(SdkRequest request) {
+    return () -> request;
+  }
+}

--- a/brave/instrumentation-awssdk-sqs/src/test/java/brave/instrumentation/awssdk/sqs/SendMessageTracingExecutionInterceptorTest.java
+++ b/brave/instrumentation-awssdk-sqs/src/test/java/brave/instrumentation/awssdk/sqs/SendMessageTracingExecutionInterceptorTest.java
@@ -81,7 +81,9 @@ class SendMessageTracingExecutionInterceptorTest {
     }
 
     // Verify Span
+    assertThat(localParent.kind()).isEqualTo(PRODUCER);
     assertThat(localParent.name()).isEqualTo("publish-batch");
+    assertThat(localParent.remoteServiceName()).isEqualToIgnoringCase("amazon-sqs");
 
     List<MutableSpan> messageSpans =
         spans.spans().stream().filter(s -> s != localParent).collect(Collectors.toList());

--- a/brave/propagation-aws/pom.xml
+++ b/brave/propagation-aws/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/collector/kinesis/README.md
+++ b/collector/kinesis/README.md
@@ -8,9 +8,9 @@ service that is effective at decoupling components of cloud applications.  Using
 in place of Kafka removes the need to stand up and manage a distributed Kafka 
 deployment.
 
-The Kinesis collector is based on the Java Kinesis Client Library ([KCL](https://github.com/awslabs/amazon-kinesis-client)). This library works much the
-same way that Kafka does when there are multiple consumers of the same stream. In the place of
-zookeeper for kafka, the KCL uses DynamoDB to do its coordination.
+The Kinesis collector is based on the [Kinesis Client Library (KCL) 3.x](https://github.com/awslabs/amazon-kinesis-client).
+This library works much the same way that Kafka does when there are multiple consumers of the same
+stream. In the place of zookeeper for kafka, the KCL uses DynamoDB to do its coordination.
 
 To fully take advantage of the KinesisCollector users will send Thrift encoded Zipkin Spans
 directly to a Kinesis stream from each service. 

--- a/collector/kinesis/pom.xml
+++ b/collector/kinesis/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -25,10 +25,20 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>
-
-    <!-- Avoid CVEs in kinesis deps -->
-    <protobuf.version>3.25.5</protobuf.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Avoid CVE in KCL transitive jackson-core 2.20.0 -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -37,33 +47,10 @@
       <version>${zipkin.version}</version>
     </dependency>
 
-    <!-- TODO: See if 'software.amazon.kinesis:amazon-kinesis-client:2.0.1' replaces this? -->
     <dependency>
-      <groupId>com.amazonaws</groupId>
+      <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>1.15.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
+      <version>3.4.1</version>
     </dependency>
 
     <dependency>

--- a/collector/kinesis/src/main/java/zipkin2/collector/kinesis/KinesisCollector.java
+++ b/collector/kinesis/src/main/java/zipkin2/collector/kinesis/KinesisCollector.java
@@ -4,17 +4,20 @@
  */
 package zipkin2.collector.kinesis;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor;
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory;
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.kinesis.common.ConfigsBuilder;
+import software.amazon.kinesis.coordinator.Scheduler;
+import software.amazon.kinesis.processor.ShardRecordProcessor;
+import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
 import zipkin2.CheckResult;
 import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
@@ -33,10 +36,10 @@ public final class KinesisCollector extends CollectorComponent {
     Collector.Builder delegate = Collector.newBuilder(KinesisCollector.class);
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
 
-    AWSCredentialsProvider credentialsProvider;
+    AwsCredentialsProvider credentialsProvider;
     String appName;
     String streamName;
-    String regionName;
+    String regionName = "us-east-1";
 
     @Override
     public Builder storage(StorageComponent storageComponent) {
@@ -57,7 +60,7 @@ public final class KinesisCollector extends CollectorComponent {
       return this;
     }
 
-    public Builder credentialsProvider(AWSCredentialsProvider credentialsProvider) {
+    public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
       this.credentialsProvider = credentialsProvider;
       return this;
     }
@@ -89,13 +92,16 @@ public final class KinesisCollector extends CollectorComponent {
   private final CollectorMetrics metrics;
   private final String appName;
   private final String streamName;
-  private final AWSCredentialsProvider credentialsProvider;
+  private final AwsCredentialsProvider credentialsProvider;
   private final String regionName;
 
   private final Executor executor;
-  private Worker worker;
+  private Scheduler scheduler;
+  private KinesisAsyncClient kinesisClient;
+  private DynamoDbAsyncClient dynamoClient;
+  private CloudWatchAsyncClient cloudWatchClient;
 
-    KinesisCollector(Builder builder) {
+  KinesisCollector(Builder builder) {
     this.collector = builder.delegate.build();
     this.metrics = builder.metrics;
     this.appName = builder.appName;
@@ -103,11 +109,12 @@ public final class KinesisCollector extends CollectorComponent {
     this.credentialsProvider = builder.credentialsProvider;
     this.regionName = builder.regionName;
 
-    executor =
-        Executors.newSingleThreadExecutor(
-            new ThreadFactoryBuilder()
-                .setNameFormat("KinesisCollector-" + streamName + "-%d")
-                .build());
+    executor = Executors.newSingleThreadExecutor(r -> {
+      Thread thread = new Thread(r);
+      thread.setName("KinesisCollector-" + streamName);
+      thread.setDaemon(true);
+      return thread;
+    });
   }
 
   @Override
@@ -119,14 +126,40 @@ public final class KinesisCollector extends CollectorComponent {
       workerId = UUID.randomUUID().toString();
     }
 
-    KinesisClientLibConfiguration config =
-        new KinesisClientLibConfiguration(appName, streamName, credentialsProvider, workerId);
-    config.withRegionName(regionName);
+    Region region = Region.of(regionName);
 
-      IRecordProcessorFactory processor = new KinesisRecordProcessorFactory(collector, metrics);
-    worker = new Worker.Builder().recordProcessorFactory(processor).config(config).build();
+    kinesisClient = KinesisAsyncClient.builder()
+        .credentialsProvider(credentialsProvider)
+        .region(region)
+        .build();
 
-    executor.execute(worker);
+    dynamoClient = DynamoDbAsyncClient.builder()
+        .credentialsProvider(credentialsProvider)
+        .region(region)
+        .build();
+
+    cloudWatchClient = CloudWatchAsyncClient.builder()
+        .credentialsProvider(credentialsProvider)
+        .region(region)
+        .build();
+
+    ShardRecordProcessorFactory processorFactory =
+        () -> new KinesisSpanProcessor(collector, metrics);
+
+    ConfigsBuilder configsBuilder = new ConfigsBuilder(
+        streamName, appName, kinesisClient, dynamoClient, cloudWatchClient,
+        workerId, processorFactory);
+
+    scheduler = new Scheduler(
+        configsBuilder.checkpointConfig(),
+        configsBuilder.coordinatorConfig(),
+        configsBuilder.leaseManagementConfig(),
+        configsBuilder.lifecycleConfig(),
+        configsBuilder.metricsConfig(),
+        configsBuilder.processorConfig(),
+        configsBuilder.retrievalConfig());
+
+    executor.execute(scheduler);
     return this;
   }
 
@@ -138,24 +171,11 @@ public final class KinesisCollector extends CollectorComponent {
 
   @Override
   public void close() {
-    // The executor is a single thread that is tied to this worker. Once the worker shuts down
-    // the executor will stop.
-    worker.shutdown();
-  }
-
-  private static final class KinesisRecordProcessorFactory implements IRecordProcessorFactory {
-
-    final Collector collector;
-    final CollectorMetrics metrics;
-
-    KinesisRecordProcessorFactory(Collector collector, CollectorMetrics metrics) {
-      this.collector = collector;
-      this.metrics = metrics;
+    if (scheduler != null) {
+      scheduler.shutdown();
     }
-
-    @Override
-    public IRecordProcessor createProcessor() {
-      return new KinesisSpanProcessor(collector, metrics);
-    }
+    if (kinesisClient != null) kinesisClient.close();
+    if (dynamoClient != null) dynamoClient.close();
+    if (cloudWatchClient != null) cloudWatchClient.close();
   }
 }

--- a/collector/kinesis/src/main/java/zipkin2/collector/kinesis/KinesisSpanProcessor.java
+++ b/collector/kinesis/src/main/java/zipkin2/collector/kinesis/KinesisSpanProcessor.java
@@ -4,16 +4,18 @@
  */
 package zipkin2.collector.kinesis;
 
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor;
-import com.amazonaws.services.kinesis.clientlibrary.types.InitializationInput;
-import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
-import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownInput;
-import com.amazonaws.services.kinesis.model.Record;
+import software.amazon.kinesis.lifecycle.events.InitializationInput;
+import software.amazon.kinesis.lifecycle.events.LeaseLostInput;
+import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
+import software.amazon.kinesis.lifecycle.events.ShardEndedInput;
+import software.amazon.kinesis.lifecycle.events.ShutdownRequestedInput;
+import software.amazon.kinesis.processor.ShardRecordProcessor;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 import zipkin2.Callback;
 import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorMetrics;
 
-final class KinesisSpanProcessor implements IRecordProcessor {
+final class KinesisSpanProcessor implements ShardRecordProcessor {
   static final Callback<Void> NOOP = new Callback<>() {
     @Override
     public void onSuccess(Void value) {
@@ -38,8 +40,9 @@ final class KinesisSpanProcessor implements IRecordProcessor {
 
   @Override
   public void processRecords(ProcessRecordsInput processRecordsInput) {
-    for (Record record : processRecordsInput.getRecords()) {
-      byte[] serialized = record.getData().array();
+    for (KinesisClientRecord record : processRecordsInput.records()) {
+      byte[] serialized = new byte[record.data().remaining()];
+      record.data().get(serialized);
       metrics.incrementMessages();
       metrics.incrementBytes(serialized.length);
       collector.acceptSpans(serialized, NOOP); // async
@@ -47,6 +50,14 @@ final class KinesisSpanProcessor implements IRecordProcessor {
   }
 
   @Override
-  public void shutdown(ShutdownInput shutdownInput) {
+  public void leaseLost(LeaseLostInput leaseLostInput) {
+  }
+
+  @Override
+  public void shardEnded(ShardEndedInput shardEndedInput) {
+  }
+
+  @Override
+  public void shutdownRequested(ShutdownRequestedInput shutdownRequestedInput) {
   }
 }

--- a/collector/kinesis/src/test/java/zipkin2/collector/kinesis/KinesisSpanProcessorTest.java
+++ b/collector/kinesis/src/test/java/zipkin2/collector/kinesis/KinesisSpanProcessorTest.java
@@ -4,8 +4,6 @@
  */
 package zipkin2.collector.kinesis;
 
-import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
-import com.amazonaws.services.kinesis.model.Record;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,6 +12,8 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
 import zipkin2.Span;
 import zipkin2.TestObjects;
 import zipkin2.codec.SpanBytesEncoder;
@@ -71,8 +71,10 @@ class KinesisSpanProcessorTest {
   void messageWithMultipleSpans(SpanBytesEncoder encoder) {
     byte[] message = encoder.encodeList(spans);
 
-    List<Record> records = Collections.singletonList(new Record().withData(ByteBuffer.wrap(message)));
-    kinesisSpanProcessor.processRecords(new ProcessRecordsInput().withRecords(records));
+    List<KinesisClientRecord> records = Collections.singletonList(
+        KinesisClientRecord.builder().data(ByteBuffer.wrap(message)).build());
+    kinesisSpanProcessor.processRecords(
+        ProcessRecordsInput.builder().records(records).build());
 
     assertThat(storage.spanStore().getTraces().size()).isEqualTo(spans.size());
   }
@@ -86,9 +88,10 @@ class KinesisSpanProcessorTest {
   @Test void collectorFailsWhenRecordEncodedAsSingleSpan() {
     Span span = TestObjects.LOTS_OF_SPANS[0];
     byte[] encodedSpan = SpanBytesEncoder.THRIFT.encode(span);
-    Record kinesisRecord = new Record().withData(ByteBuffer.wrap(encodedSpan));
+    KinesisClientRecord kinesisRecord =
+        KinesisClientRecord.builder().data(ByteBuffer.wrap(encodedSpan)).build();
     ProcessRecordsInput kinesisInput =
-        new ProcessRecordsInput().withRecords(Collections.singletonList(kinesisRecord));
+        ProcessRecordsInput.builder().records(Collections.singletonList(kinesisRecord)).build();
 
     kinesisSpanProcessor.processRecords(kinesisInput);
 
@@ -100,15 +103,15 @@ class KinesisSpanProcessorTest {
   }
 
   private ProcessRecordsInput createTestData(int count) {
-    List<Record> records = new ArrayList<>();
+    List<KinesisClientRecord> records = new ArrayList<>();
 
     Span[] spans = Arrays.copyOfRange(TestObjects.LOTS_OF_SPANS, 0, count);
 
     Arrays.stream(spans)
         .map(s -> ByteBuffer.wrap(SpanBytesEncoder.THRIFT.encodeList(Collections.singletonList(s))))
-        .map(b -> new Record().withData(b))
+        .map(b -> KinesisClientRecord.builder().data(b).build())
         .forEach(records::add);
 
-    return new ProcessRecordsInput().withRecords(records);
+    return ProcessRecordsInput.builder().records(records).build();
   }
 }

--- a/collector/sqs/README.md
+++ b/collector/sqs/README.md
@@ -10,8 +10,10 @@ deployment.
 
 To fully take advantage of the SQSCollector users will typically send Zipkin Spans
 directly to a regional SQS queue from each cloud service.  For Java applications we 
-provide the [SQS Zipkin Reporter](https://github.com/openzipkin/zipkin-aws/tree/master/sender-sqs) 
-that can be used with any tracing backend that accepts a [Zipkin Reporter](https://github.com/openzipkin/zipkin-reporter-java) 
+provide the [SQS Zipkin Reporter](https://github.com/openzipkin/zipkin-aws/tree/master/reporter/sender-awssdk-sqs)
+that can be used with any tracing backend that accepts a [Zipkin Reporter](https://github.com/openzipkin/zipkin-reporter-java)
+
+This collector uses the [AWS SDK V2](https://github.com/aws/aws-sdk-java-v2) `SqsClient`. 
 
 ## Usage
 

--- a/collector/sqs/pom.xml
+++ b/collector/sqs/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -34,27 +34,14 @@
       <version>${zipkin.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sqs</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sqs</artifactId>
+      <version>${sdk-core.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <!-- com.amazonaws.util.Base64 static initialization looks up jaxb -->
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
-      <scope>provided</scope>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>url-connection-client</artifactId>
+      <version>${sdk-core.version}</version>
     </dependency>
 
     <dependency>

--- a/collector/sqs/src/main/java/zipkin2/collector/sqs/SQSCollector.java
+++ b/collector/sqs/src/main/java/zipkin2/collector/sqs/SQSCollector.java
@@ -4,11 +4,7 @@
  */
 package zipkin2.collector.sqs;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -16,6 +12,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsClientBuilder;
 import zipkin2.CheckResult;
 import zipkin2.collector.Collector;
 import zipkin2.collector.CollectorComponent;
@@ -37,8 +39,9 @@ public final class SQSCollector extends CollectorComponent {
     String queueUrl;
     int waitTimeSeconds = 20; // aws sqs max wait time is 20 seconds
     int maxNumberOfMessages = 10; // aws sqs max messages for a receive call is 10
-    EndpointConfiguration endpointConfiguration;
-    AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
+    URI endpointOverride;
+    String region = "us-east-1";
+    AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
     int parallelism = 1;
 
     @Override
@@ -66,14 +69,20 @@ public final class SQSCollector extends CollectorComponent {
       return this;
     }
 
-    /** Endpoint and signing configuration for SQS. */
-    public Builder endpointConfiguration(EndpointConfiguration endpointConfiguration) {
-      this.endpointConfiguration = endpointConfiguration;
+    /** Endpoint override for SQS. */
+    public Builder endpointOverride(URI endpointOverride) {
+      this.endpointOverride = endpointOverride;
+      return this;
+    }
+
+    /** AWS region for SQS. */
+    public Builder region(String region) {
+      this.region = region;
       return this;
     }
 
     /** AWS credentials for authenticating calls to SQS. */
-    public Builder credentialsProvider(AWSCredentialsProvider credentialsProvider) {
+    public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
       this.credentialsProvider = credentialsProvider;
       return this;
     }
@@ -112,7 +121,7 @@ public final class SQSCollector extends CollectorComponent {
   }
 
   final AtomicBoolean closed = new AtomicBoolean(false);
-  final LazyAmazonSQSClient client;
+  final LazySqsClient client;
   final List<SQSSpanProcessor> processors = new ArrayList<>();
   final ExecutorService pool;
   final int parallelism;
@@ -123,7 +132,7 @@ public final class SQSCollector extends CollectorComponent {
   final CollectorMetrics metrics;
 
   SQSCollector(Builder builder) {
-    client = new LazyAmazonSQSClient(builder);
+    client = new LazySqsClient(builder);
     collector = builder.delegate.build();
     metrics = builder.metrics;
     parallelism = builder.parallelism;
@@ -165,7 +174,7 @@ public final class SQSCollector extends CollectorComponent {
     }
   }
 
-  AmazonSQS client() {
+  SqsClient client() {
     return client.get();
   }
 
@@ -182,21 +191,27 @@ public final class SQSCollector extends CollectorComponent {
     }
   }
 
-  private static final class LazyAmazonSQSClient {
-    final AmazonSQSClientBuilder builder;
-    volatile AmazonSQS client;
+  private static final class LazySqsClient {
+    final AwsCredentialsProvider credentialsProvider;
+    final URI endpointOverride;
+    final String region;
+    volatile SqsClient client;
 
-    LazyAmazonSQSClient(Builder builder) {
-      this.builder =
-          AmazonSQSClientBuilder.standard()
-              .withEndpointConfiguration(builder.endpointConfiguration)
-              .withCredentials(builder.credentialsProvider);
+    LazySqsClient(Builder builder) {
+      this.credentialsProvider = builder.credentialsProvider;
+      this.endpointOverride = builder.endpointOverride;
+      this.region = builder.region;
     }
 
-    AmazonSQS get() {
+    SqsClient get() {
       if (client == null) {
         synchronized (this) {
           if (client == null) {
+            SqsClientBuilder builder = SqsClient.builder()
+                .httpClient(UrlConnectionHttpClient.create())
+                .credentialsProvider(credentialsProvider);
+            if (endpointOverride != null) builder.endpointOverride(endpointOverride);
+            if (region != null) builder.region(Region.of(region));
             client = builder.build();
           }
         }
@@ -205,9 +220,9 @@ public final class SQSCollector extends CollectorComponent {
     }
 
     void close() {
-      AmazonSQS maybeClient = client;
+      SqsClient maybeClient = client;
       if (maybeClient == null) return;
-      maybeClient.shutdown();
+      maybeClient.close();
     }
   }
 }

--- a/collector/sqs/src/main/java/zipkin2/collector/sqs/SQSSpanProcessor.java
+++ b/collector/sqs/src/main/java/zipkin2/collector/sqs/SQSSpanProcessor.java
@@ -4,20 +4,21 @@
  */
 package zipkin2.collector.sqs;
 
-import com.amazonaws.AbortedException;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.DeleteMessageBatchRequestEntry;
-import com.amazonaws.services.sqs.model.Message;
-import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
-import com.amazonaws.util.Base64;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import zipkin2.Callback;
 import zipkin2.CheckResult;
 import zipkin2.Component;
@@ -32,7 +33,7 @@ final class SQSSpanProcessor extends Component implements Runnable {
   private static final long DEFAULT_BACKOFF = 100;
   private static final long MAX_BACKOFF = 30000;
 
-  final AmazonSQS client;
+  final SqsClient client;
   final Collector collector;
   final CollectorMetrics metrics;
   final String queueUrl;
@@ -47,9 +48,11 @@ final class SQSSpanProcessor extends Component implements Runnable {
     metrics = sqsCollector.metrics;
     queueUrl = sqsCollector.queueUrl;
     closed = sqsCollector.closed;
-    request = new ReceiveMessageRequest(queueUrl)
-        .withWaitTimeSeconds(sqsCollector.waitTimeSeconds)
-        .withMaxNumberOfMessages(sqsCollector.maxNumberOfMessages);
+    request = ReceiveMessageRequest.builder()
+        .queueUrl(queueUrl)
+        .waitTimeSeconds(sqsCollector.waitTimeSeconds)
+        .maxNumberOfMessages(sqsCollector.maxNumberOfMessages)
+        .build();
   }
 
   @Override
@@ -66,7 +69,7 @@ final class SQSSpanProcessor extends Component implements Runnable {
   public void run() {
     while (!closed.get()) {
       try {
-        process(client.receiveMessage(request).getMessages());
+        process(client.receiveMessage(request).messages());
         status.lazySet(CheckResult.OK);
         failureBackoff = DEFAULT_BACKOFF;
       } catch (AbortedException ae) {
@@ -94,18 +97,21 @@ final class SQSSpanProcessor extends Component implements Runnable {
     for (Message message : messages) {
       final String deleteId = String.valueOf(count++);
       try {
-        String stringBody = message.getBody();
+        String stringBody = message.body();
         if (stringBody.isEmpty() || stringBody.equals("[]")) continue;
         // allow plain-text json, but permit base64 encoded thrift or json
         byte[] serialized =
-            stringBody.charAt(0) == '[' ? stringBody.getBytes(UTF_8) : Base64.decode(stringBody);
+            stringBody.charAt(0) == '[' ? stringBody.getBytes(UTF_8)
+                : Base64.getDecoder().decode(stringBody);
         metrics.incrementMessages();
         metrics.incrementBytes(serialized.length);
         collector.acceptSpans(serialized, new Callback<>() {
           @Override
           public void onSuccess(Void value) {
-            toDelete.add(
-                new DeleteMessageBatchRequestEntry(deleteId, message.getReceiptHandle()));
+            toDelete.add(DeleteMessageBatchRequestEntry.builder()
+                .id(deleteId)
+                .receiptHandle(message.receiptHandle())
+                .build());
           }
 
           @Override
@@ -114,14 +120,19 @@ final class SQSSpanProcessor extends Component implements Runnable {
             // for cases that are not recoverable just discard the message,
             // otherwise ignore so processing can be retried.
             if (t instanceof IllegalArgumentException) {
-              toDelete.add(
-                  new DeleteMessageBatchRequestEntry(deleteId, message.getReceiptHandle()));
+              toDelete.add(DeleteMessageBatchRequestEntry.builder()
+                  .id(deleteId)
+                  .receiptHandle(message.receiptHandle())
+                  .build());
             }
           }
         });
       } catch (RuntimeException | Error e) {
         logger.log(Level.WARNING, "message decoding failed", e);
-        toDelete.add(new DeleteMessageBatchRequestEntry(deleteId, message.getReceiptHandle()));
+        toDelete.add(DeleteMessageBatchRequestEntry.builder()
+            .id(deleteId)
+            .receiptHandle(message.receiptHandle())
+            .build());
       }
     }
 
@@ -131,7 +142,10 @@ final class SQSSpanProcessor extends Component implements Runnable {
   }
 
   private void delete(List<DeleteMessageBatchRequestEntry> entries) {
-    client.deleteMessageBatch(queueUrl, entries);
+    client.deleteMessageBatch(DeleteMessageBatchRequest.builder()
+        .queueUrl(queueUrl)
+        .entries(entries)
+        .build());
   }
 
   @Override public String toString() {

--- a/collector/sqs/src/test/java/zipkin2/collector/sqs/ITSQSCollector.java
+++ b/collector/sqs/src/test/java/zipkin2/collector/sqs/ITSQSCollector.java
@@ -4,11 +4,8 @@
  */
 package zipkin2.collector.sqs;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -17,6 +14,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import zipkin2.Span;
 import zipkin2.TestObjects;
 import zipkin2.codec.SpanBytesEncoder;
@@ -50,9 +49,10 @@ class ITSQSCollector {
         .queueUrl(sqs.queueUrl())
         .parallelism(2)
         .waitTimeSeconds(1) // using short wait time to make test teardown faster
-        .endpointConfiguration(new EndpointConfiguration(sqs.queueUrl(), "us-east-1"))
+        .endpointOverride(URI.create(sqs.queueUrl()))
+        .region("us-east-1")
         .credentialsProvider(
-            new AWSStaticCredentialsProvider(new BasicAWSCredentials("x", "x")))
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
         .metrics(metrics)
         .sampler(CollectorSampler.ALWAYS_SAMPLE)
         .storage(store)

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.aws</groupId>
     <artifactId>zipkin-aws-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-module-aws</artifactId>
@@ -28,7 +28,7 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Avoid CVEs in armeria deps -->
+      <!-- Avoid CVEs in armeria and KCL transitive deps -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
@@ -37,24 +37,35 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-cbor</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>1.12.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>20240303</version>
+      </dependency>
+      <dependency>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>1.8.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>${sdk-core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -110,15 +121,14 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <groupId>com.amazonaws</groupId>
-      <version>${aws-java-sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+      <version>${sdk-core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+      <version>${sdk-core.version}</version>
     </dependency>
 
     <dependency>

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -43,21 +43,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro</artifactId>
-        <version>1.12.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.json</groupId>
-        <artifactId>json</artifactId>
-        <version>20240303</version>
-      </dependency>
-      <dependency>
-        <groupId>org.lz4</groupId>
-        <artifactId>lz4-java</artifactId>
-        <version>1.8.1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/module/src/main/java/zipkin/module/aws/elasticsearch/ZipkinElasticsearchAwsStorageModule.java
+++ b/module/src/main/java/zipkin/module/aws/elasticsearch/ZipkinElasticsearchAwsStorageModule.java
@@ -4,10 +4,6 @@
  */
 package zipkin.module.aws.elasticsearch;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSSessionCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
 import com.linecorp.armeria.client.Endpoint;
@@ -34,6 +30,10 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 @Configuration
 @EnableConfigurationProperties(ZipkinElasticsearchAwsStorageProperties.class)
@@ -88,7 +88,7 @@ class ZipkinElasticsearchAwsStorageModule {
     if (aws.getRegion() != null) {
       return aws.getRegion();
     } else if (domain != null) {
-      return new DefaultAwsRegionProviderChain().getRegion();
+      return DefaultAwsRegionProviderChain.builder().build().getRegion().id();
     } else if (hosts != null) {
       String awsRegion = regionFromAwsUrls(hosts);
       if (awsRegion == null) throw new IllegalArgumentException("Couldn't find region in " + hosts);
@@ -97,20 +97,20 @@ class ZipkinElasticsearchAwsStorageModule {
     throw new AssertionError(AwsMagic.class.getName() + " should ensure this line isn't reached");
   }
 
-  /** By default, get credentials from the {@link DefaultAWSCredentialsProviderChain} */
+  /** By default, get credentials from the {@link DefaultCredentialsProvider} */
   @Bean @ConditionalOnMissingBean
   AWSCredentials.Provider credentials() {
     return new AWSCredentials.Provider() {
-      final AWSCredentialsProvider delegate = new DefaultAWSCredentialsProviderChain();
+      final AwsCredentialsProvider delegate = DefaultCredentialsProvider.create();
 
       @Override public AWSCredentials get() {
-        com.amazonaws.auth.AWSCredentials result = delegate.getCredentials();
+        software.amazon.awssdk.auth.credentials.AwsCredentials result = delegate.resolveCredentials();
         String sessionToken =
-            result instanceof AWSSessionCredentials awssc
-                ? awssc.getSessionToken()
+            result instanceof AwsSessionCredentials awssc
+                ? awssc.sessionToken()
                 : null;
         return new AWSCredentials(
-            result.getAWSAccessKeyId(), result.getAWSSecretKey(), sessionToken);
+            result.accessKeyId(), result.secretAccessKey(), sessionToken);
       }
     };
   }

--- a/module/src/main/java/zipkin/module/aws/kinesis/ZipkinKinesisCollectorModule.java
+++ b/module/src/main/java/zipkin/module/aws/kinesis/ZipkinKinesisCollectorModule.java
@@ -4,7 +4,6 @@
  */
 package zipkin.module.aws.kinesis;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -14,6 +13,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
 import zipkin2.collector.kinesis.KinesisCollector;
@@ -28,7 +28,7 @@ class ZipkinKinesisCollectorModule {
   @Bean
   KinesisCollector kinesisCollector(
       ZipkinKinesisCollectorProperties properties,
-      AWSCredentialsProvider credentialsProvider,
+      AwsCredentialsProvider credentialsProvider,
       CollectorSampler sampler,
       CollectorMetrics metrics,
       StorageComponent storage) {
@@ -39,7 +39,8 @@ class ZipkinKinesisCollectorModule {
         .storage(storage)
         .streamName(properties.getStreamName())
         .appName(properties.getAppName())
-        .regionName(properties.getAwsKinesisRegion())
+        .regionName(properties.getAwsKinesisRegion() != null
+            ? properties.getAwsKinesisRegion() : properties.getAwsRegion())
         .build()
         .start();
   }

--- a/module/src/main/java/zipkin/module/aws/kinesis/ZipkinKinesisCredentialsConfiguration.java
+++ b/module/src/main/java/zipkin/module/aws/kinesis/ZipkinKinesisCredentialsConfiguration.java
@@ -4,13 +4,6 @@
  */
 package zipkin.module.aws.kinesis;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -21,50 +14,61 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 @Configuration
 @EnableConfigurationProperties(ZipkinKinesisCollectorProperties.class)
 @Conditional(ZipkinKinesisCollectorModule.KinesisSetCondition.class)
 class ZipkinKinesisCredentialsConfiguration {
 
-  /** Setup {@link AWSSecurityTokenService} client an IAM role to assume is given. */
+  /** Setup {@link StsClient} client an IAM role to assume is given. */
   @Bean
   @ConditionalOnMissingBean
   @Conditional(STSSetCondition.class)
-  AWSSecurityTokenService securityTokenService(ZipkinKinesisCollectorProperties properties) {
-    return AWSSecurityTokenServiceClientBuilder.standard()
-        .withCredentials(getDefaultCredentialsProvider(properties))
-        .withRegion(properties.getAwsStsRegion())
+  StsClient securityTokenService(ZipkinKinesisCollectorProperties properties) {
+    return StsClient.builder()
+        .credentialsProvider(getDefaultCredentialsProvider(properties))
+        .region(Region.of(properties.getAwsStsRegion()))
         .build();
   }
 
   @Autowired(required = false)
-  private AWSSecurityTokenService securityTokenService;
+  private StsClient securityTokenService;
 
-  /** By default, get credentials from the {@link DefaultAWSCredentialsProviderChain */
+  /** By default, get credentials from the {@link DefaultCredentialsProvider */
   @Bean
   @ConditionalOnMissingBean
-  AWSCredentialsProvider credentialsProvider(ZipkinKinesisCollectorProperties properties) {
+  AwsCredentialsProvider credentialsProvider(ZipkinKinesisCollectorProperties properties) {
     if (securityTokenService != null) {
-      return new STSAssumeRoleSessionCredentialsProvider.Builder(
-              properties.getAwsStsRoleArn(), "zipkin-server")
-          .withStsClient(securityTokenService)
+      return StsAssumeRoleCredentialsProvider.builder()
+          .stsClient(securityTokenService)
+          .refreshRequest(AssumeRoleRequest.builder()
+              .roleArn(properties.getAwsStsRoleArn())
+              .roleSessionName("zipkin-server")
+              .build())
           .build();
     } else {
       return getDefaultCredentialsProvider(properties);
     }
   }
 
-  private static AWSCredentialsProvider getDefaultCredentialsProvider(
+  private static AwsCredentialsProvider getDefaultCredentialsProvider(
       ZipkinKinesisCollectorProperties properties) {
-    AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
+    AwsCredentialsProvider provider = DefaultCredentialsProvider.create();
 
     // Create credentials provider from ID and secret if given.
     if (notNullOrEmpty(properties.getAwsAccessKeyId())
         && notNullOrEmpty(properties.getAwsSecretAccessKey())) {
       provider =
-          new AWSStaticCredentialsProvider(
-              new BasicAWSCredentials(properties.getAwsAccessKeyId(), properties.getAwsSecretAccessKey()));
+          StaticCredentialsProvider.create(
+              AwsBasicCredentials.create(properties.getAwsAccessKeyId(), properties.getAwsSecretAccessKey()));
     }
 
     return provider;

--- a/module/src/main/java/zipkin/module/aws/sqs/ZipkinSQSCollectorModule.java
+++ b/module/src/main/java/zipkin/module/aws/sqs/ZipkinSQSCollectorModule.java
@@ -4,9 +4,6 @@
  */
 package zipkin.module.aws.sqs;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
@@ -17,6 +14,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
 import zipkin2.collector.sqs.SQSCollector;
@@ -29,13 +27,10 @@ import zipkin2.storage.StorageComponent;
 @AutoConfigureAfter(name = "zipkin2.server.internal.ZipkinServerConfiguration")
 class ZipkinSQSCollectorModule {
 
-  @Autowired(required = false)
-  EndpointConfiguration endpointConfiguration;
-
   @Bean
   SQSCollector sqsCollector(
       ZipkinSQSCollectorProperties properties,
-      AWSCredentialsProvider credentialsProvider,
+      AwsCredentialsProvider credentialsProvider,
       CollectorSampler sampler,
       CollectorMetrics metrics,
       StorageComponent storage) {
@@ -44,7 +39,6 @@ class ZipkinSQSCollectorModule {
         .queueUrl(properties.getQueueUrl())
         .waitTimeSeconds(properties.getWaitTimeSeconds())
         .parallelism(properties.getParallelism())
-        .endpointConfiguration(endpointConfiguration)
         .credentialsProvider(credentialsProvider)
         .sampler(sampler)
         .metrics(metrics)

--- a/module/src/main/java/zipkin/module/aws/sqs/ZipkinSQSCredentialsConfiguration.java
+++ b/module/src/main/java/zipkin/module/aws/sqs/ZipkinSQSCredentialsConfiguration.java
@@ -4,13 +4,6 @@
  */
 package zipkin.module.aws.sqs;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -21,50 +14,61 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 @Configuration
 @EnableConfigurationProperties(ZipkinSQSCollectorProperties.class)
 @Conditional(ZipkinSQSCollectorModule.SQSSetCondition.class)
 class ZipkinSQSCredentialsConfiguration {
 
-  /** Setup {@link AWSSecurityTokenService} client an IAM role to assume is given. */
+  /** Setup {@link StsClient} client an IAM role to assume is given. */
   @Bean
   @ConditionalOnMissingBean
   @Conditional(STSSetCondition.class)
-  AWSSecurityTokenService securityTokenService(ZipkinSQSCollectorProperties properties) {
-    return AWSSecurityTokenServiceClientBuilder.standard()
-        .withCredentials(getDefaultCredentialsProvider(properties))
-        .withRegion(properties.awsStsRegion)
+  StsClient securityTokenService(ZipkinSQSCollectorProperties properties) {
+    return StsClient.builder()
+        .credentialsProvider(getDefaultCredentialsProvider(properties))
+        .region(Region.of(properties.awsStsRegion))
         .build();
   }
 
   @Autowired(required = false)
-  private AWSSecurityTokenService securityTokenService;
+  private StsClient securityTokenService;
 
-  /** By default, get credentials from the {@link DefaultAWSCredentialsProviderChain */
+  /** By default, get credentials from the {@link DefaultCredentialsProvider */
   @Bean
   @ConditionalOnMissingBean
-  AWSCredentialsProvider credentialsProvider(ZipkinSQSCollectorProperties properties) {
+  AwsCredentialsProvider credentialsProvider(ZipkinSQSCollectorProperties properties) {
     if (securityTokenService != null) {
-      return new STSAssumeRoleSessionCredentialsProvider.Builder(
-              properties.awsStsRoleArn, "zipkin-server")
-          .withStsClient(securityTokenService)
+      return StsAssumeRoleCredentialsProvider.builder()
+          .stsClient(securityTokenService)
+          .refreshRequest(AssumeRoleRequest.builder()
+              .roleArn(properties.awsStsRoleArn)
+              .roleSessionName("zipkin-server")
+              .build())
           .build();
     } else {
       return getDefaultCredentialsProvider(properties);
     }
   }
 
-  private static AWSCredentialsProvider getDefaultCredentialsProvider(
+  private static AwsCredentialsProvider getDefaultCredentialsProvider(
       ZipkinSQSCollectorProperties properties) {
-    AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
+    AwsCredentialsProvider provider = DefaultCredentialsProvider.create();
 
     // Create credentials provider from ID and secret if given.
     if (notNullOrEmpty(properties.awsAccessKeyId)
         && notNullOrEmpty(properties.awsSecretAccessKey)) {
       provider =
-          new AWSStaticCredentialsProvider(
-              new BasicAWSCredentials(properties.awsAccessKeyId, properties.awsSecretAccessKey));
+          StaticCredentialsProvider.create(
+              AwsBasicCredentials.create(properties.awsAccessKeyId, properties.awsSecretAccessKey));
     }
 
     return provider;

--- a/module/src/test/java/zipkin/module/aws/kinesis/ZipkinKinesisCollectorModuleTest.java
+++ b/module/src/test/java/zipkin/module/aws/kinesis/ZipkinKinesisCollectorModuleTest.java
@@ -4,9 +4,6 @@
  */
 package zipkin.module.aws.kinesis;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +13,9 @@ import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
 import zipkin2.collector.kinesis.KinesisCollector;
@@ -80,9 +80,9 @@ class ZipkinKinesisCollectorModuleTest {
     context.refresh();
 
     assertThat(context.getBean(KinesisCollector.class)).isNotNull();
-    assertThat(context.getBean(AWSSecurityTokenService.class)).isNotNull();
-    assertThat(context.getBean(AWSCredentialsProvider.class))
-        .isInstanceOf(STSAssumeRoleSessionCredentialsProvider.class);
+    assertThat(context.getBean(StsClient.class)).isNotNull();
+    assertThat(context.getBean(AwsCredentialsProvider.class))
+        .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
   }
 
   @Test void kinesisCollectorConfiguredWithCorrectRegion() {

--- a/module/src/test/java/zipkin/module/aws/sqs/ZipkinSQSCollectorModuleTest.java
+++ b/module/src/test/java/zipkin/module/aws/sqs/ZipkinSQSCollectorModuleTest.java
@@ -4,9 +4,6 @@
  */
 package zipkin.module.aws.sqs;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -16,6 +13,9 @@ import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import zipkin2.collector.CollectorMetrics;
 import zipkin2.collector.CollectorSampler;
 import zipkin2.collector.sqs.SQSCollector;
@@ -23,7 +23,6 @@ import zipkin2.junit.aws.AmazonSQSExtension;
 import zipkin2.storage.InMemoryStorage;
 import zipkin2.storage.StorageComponent;
 
-import static com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,14 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ZipkinSQSCollectorModuleTest {
   @RegisterExtension AmazonSQSExtension sqs = new AmazonSQSExtension();
 
-  /** Don't crash if CI box doesn't have .aws directory defined */
-  @Configuration
-  static class Region {
-    @Bean
-    EndpointConfiguration endpointConfiguration() {
-      return new EndpointConfiguration("sqs.us-east-1.amazonaws.com", "us-east-1");
-    }
-  }
   AnnotationConfigApplicationContext context;
 
   @AfterEach void close() {
@@ -50,7 +41,6 @@ class ZipkinSQSCollectorModuleTest {
       context = new AnnotationConfigApplicationContext();
       context.register(
           PropertyPlaceholderAutoConfiguration.class,
-          Region.class,
           ZipkinSQSCollectorModule.class,
           ZipkinSQSCredentialsConfiguration.class,
           InMemoryConfiguration.class);
@@ -70,16 +60,15 @@ class ZipkinSQSCollectorModuleTest {
         .applyTo(context);
     context.register(
         PropertyPlaceholderAutoConfiguration.class,
-        Region.class,
         ZipkinSQSCollectorModule.class,
         ZipkinSQSCredentialsConfiguration.class,
         InMemoryConfiguration.class);
     context.refresh();
 
     assertThat(context.getBean(SQSCollector.class)).isNotNull();
-    assertThat(context.getBean(AWSCredentialsProvider.class)).isNotNull();
+    assertThat(context.getBean(AwsCredentialsProvider.class)).isNotNull();
     assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
-        .isThrownBy(() -> context.getBean(AWSSecurityTokenService.class));
+        .isThrownBy(() -> context.getBean(StsClient.class));
   }
 
   @Test void provideCollectorComponent_setsZipkinSqsCollectorProperties() {
@@ -93,7 +82,6 @@ class ZipkinSQSCollectorModuleTest {
         .applyTo(context);
     context.register(
         PropertyPlaceholderAutoConfiguration.class,
-        Region.class,
         ZipkinSQSCollectorModule.class,
         ZipkinSQSCredentialsConfiguration.class,
         InMemoryConfiguration.class);
@@ -118,7 +106,6 @@ class ZipkinSQSCollectorModuleTest {
         .applyTo(context);
     context.register(
         PropertyPlaceholderAutoConfiguration.class,
-        Region.class,
         ZipkinSQSCollectorModule.class,
         ZipkinSQSCredentialsConfiguration.class,
         InMemoryConfiguration.class);
@@ -127,10 +114,10 @@ class ZipkinSQSCollectorModuleTest {
     assertThat(context.getBean(SQSCollector.class)).isNotNull();
     assertThat(context.getBean(ZipkinSQSCollectorProperties.class).getAwsStsRegion())
         .isEqualTo("ap-southeast-1");
-    assertThat(context.getBean(AWSSecurityTokenService.class)).isNotNull();
+    assertThat(context.getBean(StsClient.class)).isNotNull();
 
-    assertThat(context.getBean(AWSCredentialsProvider.class))
-        .isInstanceOf(STSAssumeRoleSessionCredentialsProvider.class);
+    assertThat(context.getBean(AwsCredentialsProvider.class))
+        .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
   }
 
   @Configuration

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.zipkin.aws</groupId>
   <artifactId>zipkin-aws-parent</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -20,10 +20,12 @@
     <module>brave/instrumentation-aws-java-sdk-core</module>
     <module>brave/instrumentation-aws-java-sdk-v2-core</module>
     <module>brave/instrumentation-aws-java-sdk-sqs</module>
+    <module>brave/instrumentation-awssdk-sqs</module>
     <module>brave/propagation-aws</module>
     <module>module</module>
     <module>reporter/reporter-xray-udp</module>
     <module>reporter/sender-awssdk-sqs</module>
+    <module>reporter/sender-awssdk-kinesis</module>
     <module>reporter/sender-kinesis</module>
     <module>reporter/sender-sqs</module>
     <module>storage/xray-udp</module>

--- a/reporter/reporter-xray-udp/pom.xml
+++ b/reporter/reporter-xray-udp/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-awssdk-kinesis/README.md
+++ b/reporter/sender-awssdk-kinesis/README.md
@@ -1,0 +1,51 @@
+# sender-awssdk-kinesis
+
+This component leverages [zipkin-reporter-java](https://github.com/openzipkin/zipkin-reporter-java)
+interfaces to send spans to Amazon Kinesis using the [V2 AWS SDK](https://github.com/aws/aws-sdk-java-v2)
+for collection and processing. Kinesis is an alternative to kafka that is fully managed in the AWS
+cloud.
+
+## Configuration
+
+A minimal configuration of this sender would be:
+
+```java
+sender = KinesisSender.create("my-stream");
+```
+
+Additionally, [`KinesisClient`](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/kinesis/KinesisClient.html) can be customized as needed.
+
+```java
+kinesisClient = KinesisClient.builder()
+      .httpClient(UrlConnectionHttpClient.create())
+      .region(Region.US_EAST_1)
+      .endpointOverride(URI.create("http://localhost:4566"))
+      .credentialsProvider(
+          StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
+      .build();
+
+sender = KinesisSender.newBuilder()
+    .streamName("my-stream")
+    .kinesisClient(kinesisClient)
+    .build();
+```
+
+## Requirements
+
+The credentials that your service has requires the following permissions in order to function:
+
+`kinesis:DescribeStream` for health checking
+
+`kinesis:PutRecord` for placing spans on the stream
+
+## Message encoding
+The message's binary data includes a list of spans. Supported encodings
+are the same as the http [POST /spans](http://zipkin.io/zipkin-api/#/paths/%252Fspans) body.
+
+Encoding defaults to json, but can be overridden to PROTO3 if required.
+
+# Related work
+
+[collector-kinesis](https://github.com/openzipkin/zipkin-aws/tree/master/collector/kinesis)
+integrates with zipkin-server to pull spans off of a Kinesis stream
+instead of http or kafka.

--- a/reporter/sender-awssdk-kinesis/pom.xml
+++ b/reporter/sender-awssdk-kinesis/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>zipkin-aws-parent</artifactId>
+    <groupId>io.zipkin.aws</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>zipkin-sender-awssdk-kinesis</artifactId>
+  <name>Zipkin Sender: AWS SDK V2 Kinesis</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>${zipkin-reporter.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>kinesis</artifactId>
+      <version>${sdk-core.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-context-log4j2</artifactId>
+      <version>${brave.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>url-connection-client</artifactId>
+      <version>${sdk-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/reporter/sender-awssdk-kinesis/src/main/java/zipkin2/reporter/awssdk/kinesis/KinesisSender.java
+++ b/reporter/sender-awssdk-kinesis/src/main/java/zipkin2/reporter/awssdk/kinesis/KinesisSender.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.awssdk.kinesis;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.KinesisClientBuilder;
+import software.amazon.awssdk.services.kinesis.model.PutRecordRequest;
+import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.ClosedSenderException;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.internal.Nullable;
+
+public final class KinesisSender extends BytesMessageSender.Base {
+
+  public static KinesisSender create(String streamName) {
+    return newBuilder().streamName(streamName).build();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    String streamName, region;
+    AwsCredentialsProvider credentialsProvider;
+    URI endpointOverride;
+    KinesisClient kinesisClient;
+    int messageMaxBytes = 1024 * 1024; // 1MB Kinesis limit.
+    Encoding encoding = Encoding.JSON;
+
+    Builder(KinesisSender sender) {
+      this.streamName = sender.streamName;
+      this.region = sender.region;
+      this.credentialsProvider = sender.credentialsProvider;
+      this.endpointOverride = sender.endpointOverride;
+      this.kinesisClient = sender.providedClient;
+      this.messageMaxBytes = sender.messageMaxBytes;
+      this.encoding = sender.encoding;
+    }
+
+    /** Kinesis stream to send spans. */
+    public Builder streamName(String streamName) {
+      if (streamName == null) throw new NullPointerException("streamName == null");
+      this.streamName = streamName;
+      return this;
+    }
+
+    public Builder region(String region) {
+      if (region == null) throw new NullPointerException("region == null");
+      this.region = region;
+      return this;
+    }
+
+    /** AWS credentials for authenticating calls to Kinesis. */
+    public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+      if (credentialsProvider == null) {
+        throw new NullPointerException("credentialsProvider == null");
+      }
+      this.credentialsProvider = credentialsProvider;
+      return this;
+    }
+
+    /** Endpoint override for Kinesis. */
+    public Builder endpointOverride(URI endpointOverride) {
+      if (endpointOverride == null) {
+        throw new NullPointerException("endpointOverride == null");
+      }
+      this.endpointOverride = endpointOverride;
+      return this;
+    }
+
+    /** Use a pre-built {@link KinesisClient}. */
+    public Builder kinesisClient(KinesisClient kinesisClient) {
+      if (kinesisClient == null) throw new NullPointerException("kinesisClient == null");
+      this.kinesisClient = kinesisClient;
+      return this;
+    }
+
+    /** Maximum size of a message. Kinesis max message size is 1MB */
+    public Builder messageMaxBytes(int messageMaxBytes) {
+      this.messageMaxBytes = messageMaxBytes;
+      return this;
+    }
+
+    /**
+     * Use this to change the encoding used in messages. Default is {@linkplain Encoding#JSON}
+     *
+     * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
+     */
+    public Builder encoding(Encoding encoding) {
+      if (encoding == null) throw new NullPointerException("encoding == null");
+      this.encoding = encoding;
+      return this;
+    }
+
+    public KinesisSender build() {
+      if (streamName == null) throw new NullPointerException("streamName == null");
+      return new KinesisSender(this);
+    }
+
+    Builder() {
+    }
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  final String streamName;
+  @Nullable final String region;
+  @Nullable final AwsCredentialsProvider credentialsProvider;
+  @Nullable final URI endpointOverride;
+  @Nullable final KinesisClient providedClient;
+  final int messageMaxBytes;
+
+  KinesisSender(Builder builder) {
+    super(builder.encoding);
+    this.streamName = builder.streamName;
+    this.region = builder.region;
+    this.credentialsProvider = builder.credentialsProvider;
+    this.endpointOverride = builder.endpointOverride;
+    this.providedClient = builder.kinesisClient;
+    this.messageMaxBytes = builder.messageMaxBytes;
+  }
+
+  private final AtomicReference<String> partitionKey = new AtomicReference<>("");
+
+  private String getPartitionKey() {
+    if (partitionKey.get().isEmpty()) {
+      try {
+        partitionKey.set(InetAddress.getLocalHost().getHostName());
+      } catch (UnknownHostException e) {
+        partitionKey.set(UUID.randomUUID().toString());
+      }
+    }
+    return partitionKey.get();
+  }
+
+  /** get and close are typically called from different threads */
+  volatile KinesisClient client;
+  volatile boolean closeCalled;
+
+  KinesisClient get() {
+    if (client == null) {
+      synchronized (this) {
+        if (client != null) return client;
+        if (providedClient != null) {
+          client = providedClient;
+        } else {
+          KinesisClientBuilder builder = KinesisClient.builder();
+          if (credentialsProvider != null) builder.credentialsProvider(credentialsProvider);
+          if (endpointOverride != null) builder.endpointOverride(endpointOverride);
+          if (region != null) builder.region(Region.of(region));
+          client = builder.build();
+        }
+      }
+    }
+    return client;
+  }
+
+  @Override public int messageMaxBytes() {
+    return messageMaxBytes;
+  }
+
+  @Override public void send(List<byte[]> list) {
+    if (closeCalled) throw new ClosedSenderException();
+
+    byte[] message = BytesMessageEncoder.forEncoding(encoding()).encode(list);
+
+    get().putRecord(PutRecordRequest.builder()
+        .streamName(streamName)
+        .data(SdkBytes.fromByteArray(message))
+        .partitionKey(getPartitionKey())
+        .build());
+  }
+
+  @Override public synchronized void close() {
+    if (closeCalled) return;
+    KinesisClient client = this.client;
+    if (client != null && providedClient == null) client.close();
+    closeCalled = true;
+  }
+}

--- a/reporter/sender-awssdk-kinesis/src/test/java/zipkin2/reporter/awssdk/kinesis/KinesisSenderTest.java
+++ b/reporter/sender-awssdk-kinesis/src/test/java/zipkin2/reporter/awssdk/kinesis/KinesisSenderTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.awssdk.kinesis;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Stream;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import okio.Buffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesDecoder;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.SpanBytesEncoder;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+
+class KinesisSenderTest {
+  public MockWebServer server = new MockWebServer();
+
+  // V2 SDK sync client sends JSON wire format
+  ObjectMapper mapper = new ObjectMapper();
+  KinesisSender sender;
+
+  @BeforeEach void setup() {
+    // Disable CBOR so the SDK sends JSON that MockWebServer can handle
+    System.setProperty("software.amazon.awssdk.http.async.service.impl", "");
+    System.setProperty("aws.cborEnabled", "false");
+    KinesisClient kinesisClient = KinesisClient.builder()
+        .httpClient(UrlConnectionHttpClient.create())
+        .endpointOverride(URI.create(server.url("/").toString()))
+        .region(Region.US_EAST_1)
+        .credentialsProvider(
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
+        .build();
+
+    sender = KinesisSender.newBuilder()
+        .streamName("test")
+        .kinesisClient(kinesisClient)
+        .build();
+  }
+
+  @Test void send() throws Exception {
+    server.enqueue(kinesisResponse());
+
+    sendSpans(CLIENT_SPAN, CLIENT_SPAN);
+
+    assertThat(extractSpans(server.takeRequest().getBody()))
+        .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test void send_empty() throws Exception {
+    server.enqueue(kinesisResponse());
+
+    sendSpans();
+
+    assertThat(extractSpans(server.takeRequest().getBody()))
+        .isEmpty();
+  }
+
+  @Test void send_PROTO3() throws Exception {
+    server.enqueue(kinesisResponse());
+
+    sender.close();
+    sender = sender.toBuilder().encoding(Encoding.PROTO3).build();
+
+    sendSpans(CLIENT_SPAN, CLIENT_SPAN);
+
+    assertThat(extractSpans(server.takeRequest().getBody()))
+        .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test void send_json_unicode() throws Exception {
+    server.enqueue(kinesisResponse());
+
+    Span unicode = CLIENT_SPAN.toBuilder().putTag("error", "\uD83D\uDCA9").build();
+    sendSpans(unicode);
+
+    assertThat(extractSpans(server.takeRequest().getBody())).containsExactly(unicode);
+  }
+
+  @Test void sendFailsWithException() {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_DURING_REQUEST_BODY));
+
+    assertThatThrownBy(this::sendSpans)
+        .isInstanceOf(Exception.class);
+  }
+
+  static MockResponse kinesisResponse() {
+    return new MockResponse()
+        .addHeader("Content-Type", "application/x-amz-json-1.1")
+        .setBody("{\"SequenceNumber\":\"1\",\"ShardId\":\"shardId-000000000000\"}");
+  }
+
+  List<Span> extractSpans(Buffer body) throws IOException {
+    JsonNode tree = mapper.readTree(body.inputStream());
+    // V2 SDK sends JSON with "Data" as base64-encoded bytes
+    byte[] encodedSpans = Base64.getDecoder().decode(tree.get("Data").asText());
+    if (encodedSpans[0] == '[') {
+      return SpanBytesDecoder.JSON_V2.decodeList(encodedSpans);
+    }
+    return SpanBytesDecoder.PROTO3.decodeList(encodedSpans);
+  }
+
+  void sendSpans(Span... spans) {
+    SpanBytesEncoder bytesEncoder =
+        sender.encoding() == Encoding.JSON ? SpanBytesEncoder.JSON_V2 : SpanBytesEncoder.PROTO3;
+    sender.send(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
+  }
+
+  @AfterEach void afterEachTest() throws IOException {
+    sender.close();
+    server.close();
+  }
+}

--- a/reporter/sender-awssdk-sqs/pom.xml
+++ b/reporter/sender-awssdk-sqs/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-kinesis/pom.xml
+++ b/reporter/sender-kinesis/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/reporter/sender-sqs/pom.xml
+++ b/reporter/sender-sqs/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/storage/xray-udp/pom.xml
+++ b/storage/xray-udp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>zipkin-aws-parent</artifactId>
     <groupId>io.zipkin.aws</groupId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Summary
- Ports collectors (SQS, Kinesis), module/, and aws-junit from AWS SDK v1 to v2 in-place, keeping package names
- Adds new `brave/instrumentation-awssdk-sqs` module (v2 SQS messaging instrumentation)
- Adds new `reporter/sender-awssdk-kinesis` module (v2 Kinesis sender)
- Upgrades Kinesis Client Library from 1.x to 3.4.1

## Testing

Build and verify:
```bash
$ ./mvnw -T1C -nsu verify
$ RELEASE_FROM_MAVEN_BUILD=true build-bin/docker/docker_build openzipkin/zipkin-aws:test
$ build-bin/docker/docker_test_image openzipkin/zipkin-aws:test
```

### Elasticsearch smoke test (no real credentials)

Save as `docker-compose-test-es.yaml`:
```yaml
services:
  fake-es:
    image: nginx:alpine
    networks:
      default:
        aliases:
          - fake-es.us-east-1.es.amazonaws.com
    command:
      - sh
      - -c
      - |
        apk add --no-cache openssl > /dev/null 2>&1
        openssl req -x509 -nodes -days 1 -newkey rsa:2048           -keyout /etc/ssl/key.pem -out /etc/ssl/cert.pem           -subj '/CN=fake-es.us-east-1.es.amazonaws.com' 2>/dev/null
        cat > /etc/nginx/conf.d/default.conf <<'CONF'
        server {
            listen 443 ssl;
            ssl_certificate /etc/ssl/cert.pem;
            ssl_certificate_key /etc/ssl/key.pem;
            location / {
                return 403 '{"Message":"User: anonymous is not authorized"}';
                default_type application/json;
            }
        }
        CONF
        nginx -g 'daemon off;'

  sut:
    image: openzipkin/zipkin-aws:test
    depends_on: [fake-es]
    ports: ["9411:9411"]
    environment:
      - STORAGE_TYPE=elasticsearch
      - ES_HOSTS=https://fake-es.us-east-1.es.amazonaws.com
      - ES_SSL_NO_VERIFY=true
      - AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
      - AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
```

```bash
$ docker compose -f docker-compose-test-es.yaml up -d
$ curl -s localhost:9411/health|jq .
{
  "status": "DOWN",
  "zipkin": {
    "status": "DOWN",
    "details": {
      "error": "Timed out computing health status..."
    }
  }
}

$ curl -s -w "%{http_code}" -X POST localhost:9411/api/v2/spans   -H "Content-Type: application/json"   -d '[{"traceId":"aaaa000000000001","id":"bbbb000000000001",
       "name":"test","timestamp":1000000,"duration":1000,
       "localEndpoint":{"serviceName":"smoketest"}}]'
202

$ docker compose -f docker-compose-test-es.yaml down
```

### SQS collector smoke test (no real credentials)

Save as `docker-compose-test-sqs.yaml`:
```yaml
services:
  sut:
    image: openzipkin/zipkin-aws:test
    ports: ["9411:9411"]
    environment:
      - STORAGE_TYPE=xray
      - SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/000000000000/zipkin
      - AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
      - AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
      - AWS_REGION=us-east-1
```

Server boots, v2 SqsClient loads correctly, expected 403 with fake credentials:
```
software.amazon.awssdk.services.sqs.model.SqsException: The security token included in the request
is invalid. (Service: Sqs, Status Code: 403, ...) (SDK Attempt Count: 1)
```

### Kinesis collector smoke test (no real credentials)

Save as `docker-compose-test-kinesis.yaml`:
```yaml
services:
  sut:
    image: openzipkin/zipkin-aws:test
    ports: ["9411:9411"]
    environment:
      - STORAGE_TYPE=xray
      - KINESIS_STREAM_NAME=zipkin
      - AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
      - AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
      - AWS_REGION=us-east-1
```

Server boots, KCL 3.x loads correctly, expected 400 with fake credentials:
```
software.amazon.kinesis.leases.exceptions.DependencyException:
software.amazon.awssdk.services.dynamodb.model.DynamoDbException: The security token included in the
request is invalid. (Service: DynamoDb, Status Code: 400, ...) (SDK Attempt Count: 1)
```