### PR TITLE
Bump zipkin to 3.6.1, armeria to 1.38.0, netty to 4.2.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,15 +67,15 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>3.6.0</zipkin.version>
+    <zipkin.version>3.6.1</zipkin.version>
     <zipkin-reporter.version>3.5.3</zipkin-reporter.version>
     <spring-boot.version>3.5.12</spring-boot.version>
     <jackson.version>2.21.2</jackson.version>
     <!-- This allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
-    <armeria.version>1.37.0</armeria.version>
+    <armeria.version>1.38.0</armeria.version>
     <!-- Match Armeria version to avoid conflicts including running tests in the IDE -->
-    <netty.version>4.2.11.Final</netty.version>
+    <netty.version>4.2.12.Final</netty.version>
     <log4j.version>2.25.3</log4j.version>
 
     <!-- This allows you to test feature branches with jitpack -->


### PR DESCRIPTION
Bumps zipkin to 3.6.1, which includes armeria 1.38.0 (fixes openzipkin/zipkin#3796) and netty 4.2.12.Final.
https://github.com/openzipkin/zipkin/releases/tag/3.6.1